### PR TITLE
Added support for HYBRID_SEETOUCH_KEYPAD devices.

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -184,7 +184,7 @@ class LutronXmlDbParser(object):
       for device_xml in devs:
         if device_xml.tag != 'Device':
           continue
-        if device_xml.get('DeviceType') in ('SEETOUCH_KEYPAD', 'PICO_KEYPAD'):
+        if device_xml.get('DeviceType') in ('SEETOUCH_KEYPAD', 'PICO_KEYPAD', 'HYBRID_SEETOUCH_KEYPAD'):
           keypad = self._parse_keypad(device_xml)
           area.add_keypad(keypad)
         elif device_xml.get('DeviceType') == 'MOTION_SENSOR':


### PR DESCRIPTION
The current code supports the SEETOUCH_KEYPAD devices but not the HYBRID_SEETOUCH_KEYPAD devices which are basically a keypad and a single channel dimmer in one unit. This patch simple adds the tag for the hybrid version to the list of devices that get counted as keypads.
