### PR TITLE
Fixed bug that caused a crash in __str__ and __repr__ for Buttons

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -529,11 +529,11 @@ class Button(object):
   def __str__(self):
     """Pretty printed string value of the Button object."""
     return 'Button name: "%s" num: %d action: "%s"' % (
-        self._name, self._num, self._action)
+        self._name, self._num, self._direction)
 
   def __repr__(self):
     """String representation of the Button object."""
-    return str({'name': self._name, 'num': self._num, 'action': self._action})
+    return str({'name': self._name, 'num': self._num, 'direction': self._direction})
 
   @property
   def name(self):


### PR DESCRIPTION
The implementations of `__str__()` and `__repr__()` in the current master cause a crash because they refer to an `_action` attribute that doesn't exist. They also ignored the `_direction` attribute. This patch fixes both issues.