### PR TITLE
Add support for Homeowner Keypads

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -216,7 +216,8 @@ class LutronXmlDbParser(object):
             'SEETOUCH_KEYPAD',
             'SEETOUCH_TABLETOP_KEYPAD',
             'PICO_KEYPAD',
-            'HYBRID_SEETOUCH_KEYPAD'):
+            'HYBRID_SEETOUCH_KEYPAD',
+            'HOMEOWNER_KEYPAD'):
           keypad = self._parse_keypad(device_xml)
           area.add_keypad(keypad)
         elif device_xml.get('DeviceType') == 'MOTION_SENSOR':

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'pylutron',
-    version = '0.2.0',
+    version = '0.2.1',
     license = 'MIT',
     description = 'Python library for Lutron RadioRA 2',
     author = 'Dima Zavin',


### PR DESCRIPTION
Lutron allows keypads to be added to rooms which are not
tied to physical devices, and can be controlled soley through
the LutronConnect App.  These are represented in the
`DbXmlInfo.xml` as a `<Device />` with the attribute
`DeviceType="HOMEOWNER_KEYPAD"`.

This commit adds support for those keypads during the
area parsing, and ups the version number of pypi.