### PR TITLE
Update keypad support to include the main repeater

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -216,7 +216,8 @@ class LutronXmlDbParser(object):
             'SEETOUCH_KEYPAD',
             'SEETOUCH_TABLETOP_KEYPAD',
             'PICO_KEYPAD',
-            'HYBRID_SEETOUCH_KEYPAD'):
+            'HYBRID_SEETOUCH_KEYPAD',
+            'MAIN_REPEATER'):
           keypad = self._parse_keypad(device_xml)
           area.add_keypad(keypad)
         elif device_xml.get('DeviceType') == 'MOTION_SENSOR':


### PR DESCRIPTION
RadioRA2 Main Repeaters act as a virtual keypad with 100 buttons and leds.  This change adds it to the list of devices to parse as a keypad.