### PR TITLE
Add OccupancyGroup monitoring and battery measures for Motion Sensors

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -700,7 +700,7 @@ class Button(KeypadComponent):
     }
     if action not in ev_map:
       _LOGGER.debug("Unknown action %d for button %d in keypad %d" % (
-          action, self.number, self.keypad.name))
+          action, self.number, self._keypad.name))
       return False
     self._dispatch_event(ev_map[action], {})
     return True
@@ -770,11 +770,11 @@ class Led(KeypadComponent):
                   self._keypad.name, self, action, params))
     if action != Led._ACTION_LED_STATE:
       _LOGGER.debug("Unknown action %d for led %d in keypad %d" % (
-          action, self.number, self.keypad.name))
+          action, self.number, self._keypad.name))
       return False
     elif len(params) < 1:
       _LOGGER.debug("Unknown params %s (action %d on led %d in keypad %d)" % (
-          params, action, self.number, self.keypad.name))
+          params, action, self.number, self._keypad.name))
       return False
     self._state = bool(params[0])
     self._query_waiters.notify()

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -882,7 +882,11 @@ class MotionSensor(LutronEntity):
   class Event(LutronEvent):
     """MotionSensor events that can be generated.
 
+<<<<<<< HEAD
     STATUS_CHANGED: Battery status changed
+=======
+    BATTERY_STATUS_CHANGED: Battery status changed
+>>>>>>> Add OccupancyGroup tracking and report motion sensor battery
         Params:
           power: PowerSource
           battery: BatteryStatus
@@ -901,6 +905,7 @@ class MotionSensor(LutronEntity):
     self._lutron.register_id(MotionSensor._CMD_TYPE, self)
     self._query_waiters = _RequestHelper()
     self._last_update = None
+<<<<<<< HEAD
 
   @property
   def id(self):
@@ -1030,16 +1035,150 @@ class OccupancyGroup(LutronEntity):
     return self._lutron.send(Lutron.OP_QUERY, OccupancyGroup._CMD_TYPE, self._integration_id,
                              OccupancyGroup._ACTION_STATE)
 
+=======
+
+  @property
+  def id(self):
+    """The integration id"""
+    return self._integration_id
+
+  def __str__(self):
+    """Returns a pretty-printed string for this object."""
+    return 'MotionSensor {} Id: {} Battery: {} Power: {}'.format(
+      self.name, self.id, self.battery_status, self.power_source)
+
+  def __repr__(self):
+    """String representation of the MotionSensor object."""
+    return str({'motion_sensor_name': self.name, 'id': self.id,
+                'battery' : self.battery_status,
+                'power' : self.power_source})
+
+  @property
+  def _update_age(self):
+    """Returns the time of the last poll in seconds."""
+    if self._last_update is None:
+      return 1e6
+    else:
+      return time.time() - self._last_update
+
+  @property
+  def battery_status(self):
+    """Returns the current BatteryStatus."""
+    # Battery status won't change frequently but can't be retrieved for MONITORING.
+    # So rate limit queries to once an hour.
+    if self._update_age > 3600.0:
+      ev = self._query_waiters.request(self._do_query_battery)
+      ev.wait(1.0)
+    return self._battery
+
+  @property
+  def power_source(self):
+    """Returns the current PowerSource."""
+    self.battery_status  # retrieved by the same query
+    return self._power
+
+  def _do_query_battery(self):
+    """Helper to perform the query for the current BatteryStatus."""
+    component_num = 1  # doesn't seem to matter
+    return self._lutron.send(Lutron.OP_QUERY, MotionSensor._CMD_TYPE, self._integration_id,
+                             component_num, MotionSensor._ACTION_BATTERY_STATUS)
+
+  def handle_update(self, args):
+    """Handle the specified action on this component."""
+    if len(args) != 6:
+      _LOGGER.debug('Wrong number of args for MotionSensor update {}'.format(len(args)))
+      return False
+    _, action, _, power, battery, _ = args
+    action = int(action)
+    if action != MotionSensor._ACTION_BATTERY_STATUS:
+      _LOGGER.debug("Unknown action %d for motion sensor {}".format(self.name))
+      return False
+    self._power = PowerSource(int(power))
+    self._battery = BatteryStatus(int(battery))
+    self._query_waiters.notify()
+    self._dispatch_event(
+      MotionSensor.Event.STATUS_CHANGED, {'power' : self._power, 'battery': self._battery})
+    return True
+
+
+class OccupancyGroup(LutronEntity):
+  _CMD_TYPE = 'GROUP'
+  _ACTION_STATE = 3
+
+  class State(Enum):
+    """Possible states of an OccupancyGroup."""
+    UNSET = 0
+    OCCUPIED = 3
+    VACANT = 4
+    UNKNOWN = 255
+
+  class Event(LutronEvent):
+    """OccupancyGroup event that can be generated.
+
+    OCCUPANCY_CHANGED: Occupancy state has changed.
+        Params:
+          state: an OccupancyGroup.State
+    """
+    OCCUPANCY = 1
+
+  def __init__(self, lutron, area):
+    super(OccupancyGroup, self).__init__(lutron, 'Occ {}'.format(area.name))
+    self._area = area
+    self._integration_id = area.id
+    self._state = OccupancyGroup.State.UNSET
+    self._lutron.register_id(OccupancyGroup._CMD_TYPE, self)
+    self._query_waiters = _RequestHelper()
+
+  @property
+  def id(self):
+    """The integration id"""
+    return self._integration_id
+
+  @property
+  def name(self):
+    """Return the name of this OccupancyGroup, which is 'Occ' plus the name of the area."""
+    return 'Occ {}'.format(self._area.name)
+
+  @property
+  def state(self):
+    """Returns the current occupancy state."""
+    # Poll for the first request.
+    if self._state == OccupancyGroup.State.UNSET:
+      ev = self._query_waiters.request(self._do_query_state)
+      ev.wait(1.0)
+    return self._state
+
+  def __str__(self):
+    """Returns a pretty-printed string for this object."""
+    return 'OccupancyGroup for Area "{}" Id: {} State: {}'.format(
+      self._area.name, self.id, self.state.name)
+
+  def __repr__(self):
+    """Returns a stringified representation of this object."""
+    return str({'area_name' : self.area.name,
+                'id' : self.id,
+                'state' : self.state})
+
+  def _do_query_state(self):
+    """Helper to perform the actual query for the current OccupancyGroup state."""
+    return self._lutron.send(Lutron.OP_QUERY, OccupancyGroup._CMD_TYPE, self._integration_id,
+                             OccupancyGroup._ACTION_STATE)
+
+>>>>>>> Add OccupancyGroup tracking and report motion sensor battery
 
   def handle_update(self, args):
     """Handles an event update for this object, e.g. occupancy state change."""
     action = int(args[0])
     if action != OccupancyGroup._ACTION_STATE or len(args) != 2:
       return False
+<<<<<<< HEAD
     try:
       self._state = OccupancyGroup.State(int(args[1]))
     except ValueError:
       self._state = OccupancyGroup.State.UNKNOWN
+=======
+    self._state = OccupancyGroup.State(int(args[1]))
+>>>>>>> Add OccupancyGroup tracking and report motion sensor battery
     self._query_waiters.notify()
     self._dispatch_event(OccupancyGroup.Event.OCCUPANCY, {'state': self._state})
     return True

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -882,11 +882,7 @@ class MotionSensor(LutronEntity):
   class Event(LutronEvent):
     """MotionSensor events that can be generated.
 
-<<<<<<< HEAD
     STATUS_CHANGED: Battery status changed
-=======
-    BATTERY_STATUS_CHANGED: Battery status changed
->>>>>>> Add OccupancyGroup tracking and report motion sensor battery
         Params:
           power: PowerSource
           battery: BatteryStatus
@@ -905,7 +901,6 @@ class MotionSensor(LutronEntity):
     self._lutron.register_id(MotionSensor._CMD_TYPE, self)
     self._query_waiters = _RequestHelper()
     self._last_update = None
-<<<<<<< HEAD
 
   @property
   def id(self):
@@ -1057,7 +1052,7 @@ class OccupancyGroup(LutronEntity):
   def _update_age(self):
     """Returns the time of the last poll in seconds."""
     if self._last_update is None:
-      return 1e6
+      return float('inf')
     else:
       return time.time() - self._last_update
 
@@ -1074,12 +1069,12 @@ class OccupancyGroup(LutronEntity):
   @property
   def power_source(self):
     """Returns the current PowerSource."""
-    self.battery_status  # retrieved by the same query
+    _ = self.battery_status  # retrieved by the same query
     return self._power
 
   def _do_query_battery(self):
     """Helper to perform the query for the current BatteryStatus."""
-    component_num = 1  # doesn't seem to matter
+    component_num = 2  # doesn't seem to matter
     return self._lutron.send(Lutron.OP_QUERY, MotionSensor._CMD_TYPE, self._integration_id,
                              component_num, MotionSensor._ACTION_BATTERY_STATUS)
 
@@ -1173,13 +1168,19 @@ class OccupancyGroup(LutronEntity):
     if action != OccupancyGroup._ACTION_STATE or len(args) != 2:
       return False
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> apply fixes from pull request
     try:
       self._state = OccupancyGroup.State(int(args[1]))
     except ValueError:
       self._state = OccupancyGroup.State.UNKNOWN
+<<<<<<< HEAD
 =======
     self._state = OccupancyGroup.State(int(args[1]))
 >>>>>>> Add OccupancyGroup tracking and report motion sensor battery
+=======
+>>>>>>> apply fixes from pull request
     self._query_waiters.notify()
     self._dispatch_event(OccupancyGroup.Event.OCCUPANCY, {'state': self._state})
     return True

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -967,6 +967,7 @@ class MotionSensor(LutronEntity):
 
 
 class OccupancyGroup(LutronEntity):
+  """Represents one or more occupancy/vacancy sensors grouped into an Area."""
   _CMD_TYPE = 'GROUP'
   _ACTION_STATE = 3
 

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -243,7 +243,7 @@ class LutronXmlDbParser(object):
                     name=keypad_xml.get('Name'),
                     integration_id=int(keypad_xml.get('IntegrationID')))
     components = keypad_xml.find('Components')
-    if not components:
+    if components is None:
       return keypad
     for comp in components:
       if comp.tag != 'Component':

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -882,7 +882,7 @@ class MotionSensor(LutronEntity):
   class Event(LutronEvent):
     """MotionSensor events that can be generated.
 
-    BATTERY_STATUS_CHANGED: Battery status changed
+    STATUS_CHANGED: Battery status changed
         Params:
           power: PowerSource
           battery: BatteryStatus
@@ -922,7 +922,7 @@ class MotionSensor(LutronEntity):
   def _update_age(self):
     """Returns the time of the last poll in seconds."""
     if self._last_update is None:
-      return 1e6
+      return float('inf')
     else:
       return time.time() - self._last_update
 
@@ -939,12 +939,12 @@ class MotionSensor(LutronEntity):
   @property
   def power_source(self):
     """Returns the current PowerSource."""
-    self.battery_status  # retrieved by the same query
+    _ = self.battery_status  # retrieved by the same query
     return self._power
 
   def _do_query_battery(self):
     """Helper to perform the query for the current BatteryStatus."""
-    component_num = 1  # doesn't seem to matter
+    component_num = 2  # doesn't seem to matter
     return self._lutron.send(Lutron.OP_QUERY, MotionSensor._CMD_TYPE, self._integration_id,
                              component_num, MotionSensor._ACTION_BATTERY_STATUS)
 
@@ -1036,7 +1036,10 @@ class OccupancyGroup(LutronEntity):
     action = int(args[0])
     if action != OccupancyGroup._ACTION_STATE or len(args) != 2:
       return False
-    self._state = OccupancyGroup.State(int(args[1]))
+    try:
+      self._state = OccupancyGroup.State(int(args[1]))
+    except ValueError:
+      self._state = OccupancyGroup.State.UNKNOWN
     self._query_waiters.notify()
     self._dispatch_event(OccupancyGroup.Event.OCCUPANCY, {'state': self._state})
     return True

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -217,7 +217,8 @@ class LutronXmlDbParser(object):
             'SEETOUCH_TABLETOP_KEYPAD',
             'PICO_KEYPAD',
             'HYBRID_SEETOUCH_KEYPAD',
-            'MAIN_REPEATER'):
+            'MAIN_REPEATER',
+            'HOMEOWNER_KEYPAD'):
           keypad = self._parse_keypad(device_xml)
           area.add_keypad(keypad)
         elif device_xml.get('DeviceType') == 'MOTION_SENSOR':

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -846,7 +846,9 @@ class Keypad(LutronEntity):
 class MotionSensor(object):
   """Placeholder class for the motion sensor device.
 
-  TODO: Actually implement this.
+  Although sensors are represented in the XML, all of the protocol
+  happens at the OccupancyGroup level. To read the state of an area,
+  use area.occupancy_group.
   """
   def __init__(self, lutron, name, integration_id):
     """Initializes the motion sensor object."""
@@ -855,6 +857,83 @@ class MotionSensor(object):
     self._integration_id = integration_id
 
 
+class OccupancyGroup(LutronEntity):
+  _CMD_TYPE = 'GROUP'
+  _ACTION_STATE = 3
+
+  OCCUPIED = 3
+  VACANT = 4
+  UNKNOWN = 255
+
+  class Event(LutronEvent):
+    """OccupancyGroup event that can be generated.
+
+    OCCUPANCY_CHANGED: Occupancy state has changed.
+        Params:
+          state: One of OCCUPIED/VACANT/UNKNOWN
+    """
+    OCCUPANCY = 1
+
+  def __init__(self, lutron, area):
+    super(OccupancyGroup, self).__init__(lutron, 'Occ {}'.format(area.name))
+    self._area = area
+    self._integration_id = area.id
+    self._state = OccupancyGroup.UNKNOWN
+    self._lutron.register_id(OccupancyGroup._CMD_TYPE, self)
+    self._query_waiters = _RequestHelper()
+
+  @property
+  def id(self):
+    """The integration id"""
+    return self._integration_id
+
+  @property
+  def name(self):
+    """Return the name of this OccupancyGroup, which is 'Occ' plus the name of the area."""
+    return 'Occ {}'.format(self._area.name)
+
+  @property
+  def state(self):
+    """Returns the current occupancy state."""
+    # Poll for the first request.
+    ev = self._query_waiters.request(self._do_query_state)
+    ev.wait(1.0)
+    return self._state
+
+  def __str__(self):
+    """Returns a pretty-printed string for this object."""
+    state_map = {
+      OccupancyGroup.OCCUPIED : 'occupied',
+      OccupancyGroup.VACANT : 'vacant',
+      OccupancyGroup.UNKNOWN : 'unknown',
+    }
+    state_str = state_map[self.state]
+    return 'OccupancyGroup for Area "{}" Id: {} State: {}'.format(
+      self._area.name, self.id, state_str)
+
+  def __repr__(self):
+    """Returns a stringified representation of this object."""
+    return str({'area_name' : self.area.name,
+                'id' : self.id,
+                'state' : self.state})
+
+  def _do_query_state(self):
+    """Helper to perform the actual query for the current OccupancyGroup state."""
+    return self._lutron.send(Lutron.OP_QUERY, OccupancyGroup._CMD_TYPE, self._integration_id,
+                             OccupancyGroup._ACTION_STATE)
+
+
+  def handle_update(self, args):
+    """Handles an event update for this object, e.g. occupancy state change."""
+    action = int(args[0])
+    if action != OccupancyGroup._ACTION_STATE or len(args) != 2:
+      return False
+    self._state = int(args[1])
+    self._query_waiters.notify()
+    self._dispatch_event(OccupancyGroup.Event.OCCUPANCY, {'state': self._state})
+    return True
+
+    
 class Area(object):
   """An area (i.e. a room) that contains devices/outputs/etc."""
   def __init__(self, lutron, name, integration_id, occupancy_group_id):
@@ -862,6 +941,7 @@ class Area(object):
     self._name = name
     self._integration_id = integration_id
     self._occupancy_group_id = occupancy_group_id
+    self._occupancy_group = None
     self._outputs = []
     self._keypads = []
     self._sensors = []
@@ -880,6 +960,8 @@ class Area(object):
     """Adds a motion sensor object that's part of this area, only used during
     initial parsing."""
     self._sensors.append(sensor)
+    if not self._occupancy_group:
+      self._occupancy_group = OccupancyGroup(self._lutron, self)
 
   @property
   def name(self):
@@ -890,6 +972,11 @@ class Area(object):
   def id(self):
     """The integration id of the area."""
     return self._integration_id
+
+  @property
+  def occupancy_group(self):
+    """Returns the OccupancyGroup for this area, or None."""
+    return self._occupancy_group
 
   @property
   def outputs(self):

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -118,7 +118,7 @@ class LutronConnection(threading.Thread):
   def _maybe_reconnect(self):
     """Reconnects to the controller if we have been previously disconnected."""
     with self._lock:
-      if not self._connected: 
+      if not self._connected:
         _LOGGER.info("Connecting")
         self._do_login_locked()
         self._connected = True
@@ -186,7 +186,7 @@ class LutronXmlDbParser(object):
     areas = top_area.find('Areas')
     for area_xml in areas.getiterator('Area'):
       area = self._parse_area(area_xml)
-      self.areas.append(area)      
+      self.areas.append(area)
     return True
 
   def _parse_area(self, area_xml):
@@ -592,7 +592,7 @@ class Output(LutronEntity):
         Output._ACTION_ZONE_LEVEL, "%.2f" % new_level)
     self._level = new_level
 
-## At some later date, we may want to also specify fade and delay times    
+## At some later date, we may want to also specify fade and delay times
 #  def set_level(self, new_level, fade_time, delay):
 #    self._lutron.send(Lutron.OP_EXECUTE, Output._CMD_TYPE,
 #        Output._ACTION_ZONE_LEVEL, new_level, fade_time, delay)
@@ -783,7 +783,7 @@ class Led(KeypadComponent):
 
 class Keypad(LutronEntity):
   """Object representing a Lutron keypad.
-  
+
   Currently we don't really do much with it except handle the events
   (and drop them on the floor).
   """
@@ -844,7 +844,7 @@ class Keypad(LutronEntity):
 
 class MotionSensor(object):
   """Placeholder class for the motion sensor device.
-  
+
   TODO: Actually implement this.
   """
   def __init__(self, lutron, name, integration_id):
@@ -904,4 +904,3 @@ class Area(object):
   def sensors(self):
     """Return the tuple of the MotionSensors from this area."""
     return tuple(sensor for sensor in self._sensors)
-

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -1102,6 +1102,7 @@ class OccupancyGroup(LutronEntity):
 
 
 class OccupancyGroup(LutronEntity):
+  """Represents one or more occupancy/vacancy sensors grouped into an Area."""
   _CMD_TYPE = 'GROUP'
   _ACTION_STATE = 3
 

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -901,7 +901,6 @@ class MotionSensor(LutronEntity):
     self._lutron.register_id(MotionSensor._CMD_TYPE, self)
     self._query_waiters = _RequestHelper()
     self._last_update = None
-<<<<<<< HEAD
 
   @property
   def id(self):


### PR DESCRIPTION
Adds an OccupancyGroup object which reports the occupancy status of a set of Lutron Powr Savr motion sensors. An OccupancyGroup is attached to an Area. Also add battery reporting for MotionSensor, which is the only piece of information you can get about an individual sensor.