### PR TITLE
Fix the stacktrace in https://github.com/thecynic/pylutron/issues/17

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -87,6 +87,7 @@ class LutronConnection(threading.Thread):
 
     Must not hold self._lock.
     """
+    self._maybe_reconnect()
     with self._lock:
       self._send_locked(cmd)
 


### PR DESCRIPTION
This simply calls maybe_reconnect on every send.  This change only makes this call from the public send() method, avoiding the recursion issue from do_login noted in the issue.

This fix does NOT detect if the socket is still functional.