### PR TITLE
Add the ability to release a button, as well as tap a button.

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -749,6 +749,16 @@ class Button(KeypadComponent):
     self._lutron.send(Lutron.OP_EXECUTE, Keypad._CMD_TYPE, self._keypad.id,
                       self.component_number, Button._ACTION_PRESS)
 
+  def release(self):
+    """Triggers a simulated button release to the Keypad."""
+    self._lutron.send(Lutron.OP_EXECUTE, Keypad._CMD_TYPE, self._keypad.id,
+                      self.component_number, Button._ACTION_RELEASE)
+
+  def tap(self):
+    """Triggers a simulated button tap to the Keypad."""
+    self.press()
+    self.release()
+
   def handle_update(self, action, params):
     """Handle the specified action on this component."""
     _LOGGER.debug('Keypad: "%s" %s Action: %s Params: %s"' % (


### PR DESCRIPTION
This provides the ability to use Alarm buttons where the active
state is triggered with a button press and disabled with a release
event.