### PR TITLE
Updates the device get filter to allow legacy HWI_Keypads (1 line of code)

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -248,6 +248,7 @@ class LutronXmlDbParser(object):
         if device_xml.tag != 'Device':
           continue
         if device_xml.get('DeviceType') in (
+            'HWI_SEETOUCH_KEYPAD'
             'SEETOUCH_KEYPAD',
             'SEETOUCH_TABLETOP_KEYPAD',
             'PICO_KEYPAD',

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -248,7 +248,7 @@ class LutronXmlDbParser(object):
         if device_xml.tag != 'Device':
           continue
         if device_xml.get('DeviceType') in (
-            'HWI_SEETOUCH_KEYPAD'
+            'HWI_SEETOUCH_KEYPAD',
             'SEETOUCH_KEYPAD',
             'SEETOUCH_TABLETOP_KEYPAD',
             'PICO_KEYPAD',


### PR DESCRIPTION
This updates the device_xml.get filter to include legacy Homeworks Keypads for people using Homeworks QS with legacy keypads.

It would be nice to see this line added and then integrated with the base code in Homeworks.  I have fully tested this on my end and it works great!