### PR TITLE
Improve reliability and support for other platforms

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -163,7 +163,8 @@ class LutronConnection(threading.Thread):
           line = t.read_until(b"\n", timeout=3)
         else:
           raise EOFError('Telnet object already torn down')
-      except (EOFError, TimeoutError, socket.timeout):
+      # OSError: [Errno 101] Network unreachable
+      except (OSError, EOFError, TimeoutError, socket.timeout):
         try:
           self._lock.acquire()
           self._disconnect_locked()


### PR DESCRIPTION
- Support platforms which dont have TCP_KEEPIDLE
- Add delay on reconnect to avoid disconnect loops
- Remove AttributeError from connection failure exceptions
- Handle OSErrors in sockets

Refs #17 
Refs home-assistant/home-assistant#29642