### PR TITLE
Fix xml iterators to be compatible with python 3

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -244,7 +244,7 @@ class LutronXmlDbParser(object):
     # other assets and attributes.  Here we index the groups to be bound to
     # Areas later.
     groups = root.find('OccupancyGroups')
-    for group_xml in groups.getiterator('OccupancyGroup'):
+    for group_xml in groups.iter('OccupancyGroup'):
       group = self._parse_occupancy_group(group_xml)
       if group.group_number:
         self._occupancy_groups[group.group_number] = group
@@ -256,7 +256,7 @@ class LutronXmlDbParser(object):
     top_area = root.find('Areas').find('Area')
     self.project_name = top_area.get('Name')
     areas = top_area.find('Areas')
-    for area_xml in areas.getiterator('Area'):
+    for area_xml in areas.iter('Area'):
       area = self._parse_area(area_xml)
       self.areas.append(area)
     return True


### PR DESCRIPTION
getiterator was deprecated in 2.7.  Python 3.9 has finally removed it.  iter() is the appropriate method.

This will fix https://github.com/home-assistant/core/issues/52640