### PR TITLE
bump pylutron to 0.2.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'pylutron',
-    version = '0.2.6',
+    version = '0.2.8',
     license = 'MIT',
     description = 'Python library for Lutron RadioRA 2',
     author = 'Dima Zavin',


### PR DESCRIPTION
already published `0.2.8` to pypi, just retroactively bumping the version here to match reality