### PR TITLE
chore(ci): automate releases with tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish Python 🐍 distributions 📦 to PyPI
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get tagged version
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      - name: Replace tag template in `setup.py`
+        env:
+          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
+        run: |
+          echo replacing TEMPLATE_VERSION in setup.py with $RELEASE_VERSION...
+          sed -i "s|TEMPLATE_VERSION|$RELEASE_VERSION|" setup.py
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          python -m twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'pylutron',
-    version = '0.2.8',
+    version = 'TEMPLATE_VERSION',
     license = 'MIT',
     description = 'Python library for Lutron RadioRA 2',
     author = 'Dima Zavin',


### PR DESCRIPTION
The purpose of this PR is to automate releases with the creation of tags. I've templatized the `version` in the `setup.py` - when a release is created, the CI runs and replaces the literal string `TEMPLATE_VERSION` with the tag version. CI then pushes to PyPI using the creds stored as a secret in this repo, assuming https://github.com/thecynic/pylutron/issues/68 gets resolved. 