### PR TITLE
fix(occupancy): fix groups geting created for all areas

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -246,9 +246,10 @@ class LutronXmlDbParser(object):
     groups = root.find('OccupancyGroups')
     for group_xml in groups.iter('OccupancyGroup'):
       group = self._parse_occupancy_group(group_xml)
-      if group.group_number:
-        self._occupancy_groups[group.group_number] = group
-      else:
+      try:
+        if group.group_number:
+          self._occupancy_groups[group.group_number] = group
+      except:
         _LOGGER.warning("Occupancy Group has no number.  XML: %s", group_xml)
 
     # First area is useless, it's the top-level project area that defines the
@@ -395,9 +396,15 @@ class LutronXmlDbParser(object):
     These are defined outside of the areas in the XML.  Areas refer to these
     objects by ID.
     """
-    return OccupancyGroup(self._lutron,
+    try:
+      if group_xml.findall(".//Action"):
+        _LOGGER.debug(f"returning an occupancy group because an Action was found")
+        return OccupancyGroup(self._lutron,
                           group_number=group_xml.get('OccupancyGroupNumber'),
                           uuid=group_xml.get('UUID'))
+    except:
+      _LOGGER.error(f"threw an exception while looking for an Occupancy Group Action")
+      return None
 
 class Lutron(object):
   """Main Lutron Controller class.


### PR DESCRIPTION
fixes https://github.com/thecynic/pylutron/issues/71

This feels like a major hack, but it's at least a start to get some ideas going on what the correct fix is for this. Currently, as described in https://github.com/thecynic/pylutron/issues/71, occupancy groups are created for all areas. This is undesirable behavior as not all areas are required to have one of more Lutron PIRs. 
In this fix, I chose to look at each `OccupancyGroup` to see if there are is any `Action` defined to determine if an OccupancyGroup should be created for each area.
Below you can see a few examples of what an `OccupancyGroup` looks like from my Lutron config. This assumption may be naive, but it's the best I could come up with based on my config. If we cannot find the `Action` key under an `OccupanyGroup`, then we `return None` from `_parse_occupancy_group` as my assumption would be that there is no actual PIR in that area.

Group with an empty `Actions` element - nothing actually happens (from a Lutron perspective) when this PIR is violated:
```
        <OccupancyGroup UUID="3022" OccupancyGroupNumber="3022" ButtonType="DualAction" PrimaryActionType="3" SceneSaver="false" CycleDim="false" AllowDoubleTap="true" StopIfMoving="false" ProgrammingModelID="3085">
            <Actions />
        </OccupancyGroup>
```

Group with no `Actions`
```
        <OccupancyGroup UUID="3033" OccupancyGroupNumber="3033" />
```

Group with `Actions`:
```
        <OccupancyGroup UUID="3090" OccupancyGroupNumber="3090" ButtonType="DualAction" PrimaryActionType="3" SceneSaver="false" CycleDim="false" AllowDoubleTap="true" StopIfMoving="false" ProgrammingModelID="3117">
            <Actions>
                <Action Name="Press" ActionType="3">
                    <Presets>
                        <Preset Name="Occupied" UUID="3118">
                            <PresetAssignments>
                                <PresetAssignment UUID="3212" AssignmentName="GOTO_LEVEL" AssignmentType="2">
                                    <Delay>00:00:00.00</Delay>
                                    <Fade>00:00:00.00</Fade>
                                    <Level>100.00</Level>
                                    <IntegrationID>10</IntegrationID>
                                </PresetAssignment>
                            </PresetAssignments>
                        </Preset>
                    </Presets>
                </Action>
                <Action Name="Release" ActionType="4">
                    <Presets>
                        <Preset Name="Unoccupied" UUID="3119">
                            <PresetAssignments>
                                <PresetAssignment UUID="3213" AssignmentName="GOTO_LEVEL" AssignmentType="2">
                                    <Delay>00:00:00.00</Delay>
                                    <Fade>00:00:00.00</Fade>
                                    <Level>0.00</Level>
                                    <IntegrationID>10</IntegrationID>
                                </PresetAssignment>
                            </PresetAssignments>
                        </Preset>
                    </Presets>
                </Action>
            </Actions>
        </OccupancyGroup>
```