### PR TITLE
Generate Legacy UUIDs using IntegrationIDs and other information.

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -389,7 +389,7 @@ class LutronXmlDbParser(object):
     return MotionSensor(self._lutron,
                         name=sensor_xml.get('Name'),
                         integration_id=int(sensor_xml.get('IntegrationID')),
-                        uuid=sensor_xml.get('UUID'))
+                        uuid=sensor_xml.get('UUID') or sensor_xml.get('IntegrationID'))
 
   def _parse_occupancy_group(self, group_xml):
     """Parses an Occupancy Group object.
@@ -1204,6 +1204,8 @@ class OccupancyGroup(LutronEntity):
   def _bind_area(self, area):
     self._area = area
     self._integration_id = area.id
+    if self._uuid is None:
+      self._uuid = '%s-%s' % (area.id, self._group_number)
     self._lutron.register_id(OccupancyGroup._CMD_TYPE, self)
 
   @property

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -316,7 +316,7 @@ class LutronXmlDbParser(object):
       'watts': int(output_xml.get('Wattage')),
       'output_type': output_type,
       'integration_id': int(output_xml.get('IntegrationID')),
-      'uuid': output_xml.get('UUID')
+      'uuid': output_xml.get('UUID') or '%s-0' % output_xml.get('IntegrationID')
     }
     if output_type == 'SYSTEM_SHADE':
       return Shade(self._lutron, **kwargs)
@@ -329,7 +329,7 @@ class LutronXmlDbParser(object):
                     keypad_type=keypad_xml.get('DeviceType'),
                     location=device_group.get('Name'),
                     integration_id=int(keypad_xml.get('IntegrationID')),
-                    uuid=keypad_xml.get('UUID'))
+                    uuid=keypad_xml.get('UUID') or '%s-0' % keypad_xml.get('IntegrationID'))
     components = keypad_xml.find('Components')
     if components is None:
       return keypad
@@ -361,7 +361,7 @@ class LutronXmlDbParser(object):
                     num=int(component_xml.get('ComponentNumber')),
                     button_type=button_type,
                     direction=direction,
-                    uuid=button_xml.get('UUID'))
+                    uuid=button_xml.get('UUID') or '%d-%s' % (keypad.id, component_xml.get('ComponentNumber')))
     return button
 
   def _parse_led(self, keypad, component_xml):
@@ -375,7 +375,7 @@ class LutronXmlDbParser(object):
               name=('LED %d' % led_num),
               led_num=led_num,
               component_num=component_num,
-              uuid=component_xml.find('LED').get('UUID'))
+              uuid=component_xml.find('LED').get('UUID') or '%d-%d' % (keypad.id, component_num))
     return led
 
   def _parse_motion_sensor(self, sensor_xml):


### PR DESCRIPTION
Some older versions of firmware do not support UUIDs.  This change adds legacy_uuid property to classes that do the following:

- Use the IntegrationID
- If there's no IntegrationID, use the parent's integration ID + the item's component ID
- Occupancy groups use the area's integrationid + the group id
