### PR TITLE
Add support for HVAC controls

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -791,7 +791,7 @@ class HVAC(LutronEntity):
         self._integration_id = integration_id
         self._lutron.register_id(HVAC._CMD_TYPE, self)
         self._temp_units = "F" if temp_units == 1 else "C"
-        self._heat_cool_delta = heat_cool_delta
+        self._heat_cool_delta = heat_cool_delta if heat_cool_delta else 3
         self._operating_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_op_modes)]
         self._fan_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_fan_modes)]
         self._avail_misc_features = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_misc_features)]

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -821,6 +821,11 @@ class HVAC(LutronEntity):
         """The integration id"""
         return self._integration_id
 
+    @property
+    def avail_misc_features(self):
+        """The available miscellaneous features"""
+        return self._avail_misc_features
+
     def handle_update(self, args):
         """Handles an event update for this object, e.g. temp level change."""
         _LOGGER.debug("handle_update %d -- %s" % (self._integration_id, args))

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -293,6 +293,7 @@ class LutronXmlDbParser(object):
       'max_temp_cool': hvac_xml.get('MaxCoolSet'),
       'min_temp_heat': hvac_xml.get('MinHeatSet'),
       'max_temp_heat': hvac_xml.get('MaxHeatSet'),
+      'heat_cool_delta': hvac_xml.get('HeatCoolDelta'),
     }
     return HVAC(self._lutron, **kwargs)
 
@@ -782,6 +783,7 @@ class HVAC(LutronEntity):
         max_temp_cool,
         min_temp_heat,
         max_temp_heat,
+        heat_cool_delta,
     ):
         """Initializes the HVAC controller."""
         super(HVAC, self).__init__(lutron, name, uuid)
@@ -789,6 +791,7 @@ class HVAC(LutronEntity):
         self._integration_id = integration_id
         self._lutron.register_id(HVAC._CMD_TYPE, self)
         self._temp_units = "F" if temp_units == 1 else "C"
+        self._heat_cool_delta = heat_cool_delta
         self._operating_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_op_modes)]
         self._fan_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_fan_modes)]
         self._avail_misc_features = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_misc_features)]
@@ -827,6 +830,11 @@ class HVAC(LutronEntity):
     def avail_misc_features(self):
         """The available miscellaneous features"""
         return self._avail_misc_features
+    
+    @property
+    def heat_cool_delta(self):
+        """The required delta between heat and cool setpoints"""
+        return self._heat_cool_delta
 
     def handle_update(self, args):
         """Handles an event update for this object, e.g. temp level change."""

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -868,6 +868,7 @@ class HVAC(LutronEntity):
 
         def _u_fan_mode(mode):
             """Handles fan mode interaction"""
+            _LOGGER.info('################ UPDATING HVAC FAN MODE %s as %s', self._current_fan,HVAC.FanModes(int(mode)).name)
             if self._current_fan != HVAC.FanModes(int(mode)).name:
               self._current_fan = HVAC.FanModes(int(mode)).name
             self._query_waiters.notify()
@@ -1099,6 +1100,7 @@ class HVAC(LutronEntity):
         """Returns the current fan mode by querying the remote controller."""
         ev = self._query_waiters.request(self.__do_query_current_fan_mode)
         ev.wait(1.0)
+        _LOGGER.info('################ RETURNING HVAC FAN MODE %s ', self._current_fan)
         return self._current_fan
 
     @current_mode.setter

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -1086,7 +1086,7 @@ class HVAC(LutronEntity):
         str(HVAC.Event.OPERATING_MODE.value), mode)
         self._current_mode = new_mode
 
-    def __do_query_current_fan_mode(self):
+    def __do_query_current_fan(self):
         """Helper to perform the actual query of the fan mode"""
         self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
             HVAC.Event.FAN_MODE.value)
@@ -1096,16 +1096,16 @@ class HVAC(LutronEntity):
         return self._current_fan
 
     @property
-    def current_fan_mode(self):
+    def current_fan(self):
         """Returns the current fan mode by querying the remote controller."""
         _LOGGER.info('################ 1RETURNING HVAC FAN MODE %s ', self._current_fan)
-        ev = self._query_waiters.request(self.__do_query_current_fan_mode)
+        ev = self._query_waiters.request(self.__do_query_current_fan)
         ev.wait(1.0)
         _LOGGER.info('################ 2RETURNING HVAC FAN MODE %s ', self._current_fan)
         return self._current_fan
 
-    @current_mode.setter
-    def current_fan_mode(self, new_mode):
+    @current_fan.setter
+    def current_fan(self, new_mode):
         """Sets the new fan mode."""
         if self._current_fan == new_mode:
             return

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -778,8 +778,8 @@ class HVAC(LutronEntity):
         self._integration_id = integration_id
         self._lutron.register_id(HVAC._CMD_TYPE, self)
         self._temp_units = "F" if temp_units == 1 else "C"
-        self._operating_modes = re.split(r"\s*,\s*", avail_op_modes)
-        self._fan_modes = re.split(r"\s*,\s*", avail_fan_modes)
+        self._operating_modes = re.split(r"\s*,\s*", avail_op_modes.upper())
+        self._fan_modes = re.split(r"\s*,\s*", avail_fan_modes.upper())
         self._call_status = None
         self._schedule_status = None
         self._current_fan = None

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -808,6 +808,7 @@ class HVAC(LutronEntity):
         self._setpoint_cool_f = 0
         self._setpoint_heat_f = 0
         _LOGGER.info("################ DONE INIT HVAC %s", vars(self))
+        _LOGGER.error('################ ECO init %s ', self._eco_mode)
 
     def __str__(self):
         """Returns a pretty-printed string for this object."""
@@ -1126,6 +1127,7 @@ class HVAC(LutronEntity):
 
     def last_eco_mode(self):
         """Returns last cached value of the eco mode, no query is performed."""
+        _LOGGER.error('################ ECO %s ', self._eco_mode)
         return self._eco_mode
 
     @property

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -924,7 +924,7 @@ class HVAC(LutronEntity):
       ev.wait(1.0)
       return self.setpoint_heat_f
 
-    @setpoint_cool.setter_f
+    @setpoint_cool_f.setter
     def setpoint_cool_f(self, new_setpoint):
       """Sets the new temp level."""
       if self._setpoint_cool_f == new_setpoint:
@@ -933,7 +933,7 @@ class HVAC(LutronEntity):
           str(HVAC.Event.TEMP_SETPOINTS_F.value), str(self._setpoint_heat_f), str(new_setpoint))
       self._setpoint_cool_f = new_setpoint
   
-    @setpoint_heat.setter_f
+    @setpoint_heat_f.setter
     def setpoint_heat_f(self, new_setpoint):
       """Sets the new temp level."""
       if self._setpoint_heat_f == new_setpoint:
@@ -970,7 +970,7 @@ class HVAC(LutronEntity):
       ev.wait(1.0)
       return self.setpoint_heat_c
 
-    @setpoint_cool.setter_c
+    @setpoint_cool_c.setter
     def setpoint_cool_c(self, new_setpoint):
       """Sets the new temp level."""
       if self._setpoint_cool_c == new_setpoint:
@@ -979,7 +979,7 @@ class HVAC(LutronEntity):
           str(HVAC.Event.TEMP_SETPOINTS_C.value), str(self._setpoint_heat_c), str(new_setpoint))
       self._setpoint_cool_c = new_setpoint
   
-    @setpoint_heat.setter_c
+    @setpoint_heat_c.setter
     def setpoint_heat_c(self, new_setpoint):
       """Sets the new temp level."""
       if self._setpoint_heat_c == new_setpoint:

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -893,7 +893,7 @@ class HVAC(LutronEntity):
           HVAC.Event.FAN_MODE: (_u_fan_mode, 1),
           HVAC.Event.CALL_STATUS: (_u_call_status,1),
           HVAC.Event.TEMP_CURRENT_C: (_u_current_temp_c, 1),
-          HVAC.Event.TEMP_SETPOINTS_C: (_u_setpoints_c, 1),
+          HVAC.Event.TEMP_SETPOINTS_C: (_u_setpoints_c, 2),
           HVAC.Event.SCHEDULE_STATUS: (_u_schedule_status, 1),
         }
         if event in handler_functions:

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -268,12 +268,14 @@ class LutronXmlDbParser(object):
     # schedules could be added in a later version
     hvac_area = root.find('HVACs')
     for hvac_xml in hvac_area.iter('HVAC'):
+      _LOGGER.info('################ FOUND HVAC')
       hvac = self._parse_hvac(hvac_xml)
       self.hvacs.append(hvac)
     return True
   
   def _parse_hvac(self, hvac_xml):
     """Parses an HVAC, which is generally a thermostat controlling a heating ventilation and cooling unit"""
+    _LOGGER.info('################ START PARSING HVAC %s', hvac_xml.get('Name'))
     kwargs = {
       'name': hvac_xml.get('Name'),
       'integration_id': int(hvac_xml.get('IntegrationID')),
@@ -740,6 +742,7 @@ class HVAC(LutronEntity):
     self._current_temp = None
     self._setpoint_cool = None
     self._setpoint_heat = None
+    _LOGGER.info('################ DONE INIT HVAC ')
 
   def __str__(self):
     """Returns a pretty-printed string for this object."""

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -829,11 +829,11 @@ class HVAC(LutronEntity):
 
     event = int(args[0])
     handler_functions = {
-        Event.TEMP_CURRENT_F: (_u_current_temp, 1),
-        Event.TEMP_SETPOINTS_F: (_u_setpoints, 2),
-        Event.OPERATING_MODE: (_u_operating_mode, 1),
-        Event.FAN_MODE: (_u_fan_mode, 1),
-        Event.CALL_STATUS: (_u_call_status,1)
+        HVAC.Event.TEMP_CURRENT_F: (_u_current_temp, 1),
+        HVAC.Event.TEMP_SETPOINTS_F: (_u_setpoints, 2),
+        HVAC.Event.OPERATING_MODE: (_u_operating_mode, 1),
+        HVAC.Event.FAN_MODE: (_u_fan_mode, 1),
+        HVAC.Event.CALL_STATUS: (_u_call_status,1)
     }
     if event in handler_functions:
         handler, num_args = handler_functions[event]
@@ -848,7 +848,7 @@ class HVAC(LutronEntity):
     """Helper to perform the actual query the current temp level of the
     thermostat."""
     self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
-            Event.TEMP_CURRENT_F)
+            HVAC.Event.TEMP_CURRENT_F)
 
   def last_temp(self):
     """Returns last cached value of the temp level, no query is performed."""

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -852,13 +852,14 @@ class HVAC(LutronEntity):
 
         def _u_setpoints_f(heat, cool):
             """Handles setpoint interaction"""
+            notify = False
             if self._setpoint_cool_f != float(cool):
               self._setpoint_cool_f = float(cool)
               notify = True
             if self._setpoint_heat_f != float(heat):
               self._setpoint_heat_f = float(heat)
               notify = True
-            if notify is not None:
+            if notify:
               self._query_waiters.notify()
               self._dispatch_event(HVAC.Event.TEMP_SETPOINTS_F, {'setpoints_f': self._setpoint_cool_f})
               return True
@@ -866,13 +867,14 @@ class HVAC(LutronEntity):
         
         def _u_setpoints_c(heat, cool):
             """Handles setpoint interaction"""
+            notify = False
             if self._setpoint_cool_c != float(cool):
               self._setpoint_cool_c = float(cool)
               notify = True
             if self._setpoint_heat_c != float(heat):
               self._setpoint_heat_c = float(heat)
               notify = True
-            if notify is not None:
+            if notify:
               self._query_waiters.notify()
               self._dispatch_event(HVAC.Event.TEMP_SETPOINTS_C, {'setpoints_c': self._setpoint_cool_c})
               return True

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -828,7 +828,8 @@ class HVAC(LutronEntity):
       self._dispatch_event(HVAC.Event.CALL_STATUS, {'call_status': self._call_status})
       return True
 
-    event = int(args[0])
+    event = getattr(HVAC.Event, args[0]).value
+    _LOGGER.info('################ HAVE IT A %s', event)
     handler_functions = {
         HVAC.Event.TEMP_CURRENT_F: (_u_current_temp, 1),
         HVAC.Event.TEMP_SETPOINTS_F: (_u_setpoints, 2),
@@ -837,6 +838,7 @@ class HVAC(LutronEntity):
         HVAC.Event.CALL_STATUS: (_u_call_status,1)
     }
     if event in handler_functions:
+        _LOGGER.info('################ HAVE IT %s', event)
         handler, num_args = handler_functions[event]
         if num_args == 1:
             handler(args[1])

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -779,8 +779,8 @@ class HVAC(LutronEntity):
         self._integration_id = integration_id
         self._lutron.register_id(HVAC._CMD_TYPE, self)
         self._temp_units = "F" if temp_units == 1 else "C"
-        self._operating_modes = [slugify(mode.upper(), separator='_') for mode in re.split(r"\s*,\s*", avail_op_modes)]
-        self._fan_modes = [slugify(mode.upper(), separator='_') for mode in re.split(r"\s*,\s*", avail_fan_modes)]
+        self._operating_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_op_modes)]
+        self._fan_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_fan_modes)]
         self._call_status = None
         self._schedule_status = None
         self._current_fan = None

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -812,30 +812,36 @@ class HVAC(LutronEntity):
 
         def _u_current_temp_f(temp):
             """Handles current temp interaction"""
-            self._current_temp_f = float(temp)
+            if self._current_temp_f != float(temp):
+              self._current_temp_f = float(temp)
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.TEMP_CURRENT_F, {'current_temp_f': self._current_temp})
             return True
         
         def _u_current_temp_c(temp):
             """Handles current temp interaction"""
-            self._current_temp_c = float(temp)
+            if self._current_temp_c != float(temp):
+              self._current_temp_c = float(temp)
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.TEMP_CURRENT_C, {'current_temp_c': self._current_temp})
             return True
 
         def _u_setpoints_f(heat, cool):
             """Handles setpoint interaction"""
-            self._setpoint_cool_f = float(cool)
-            self._setpoint_heat_f = float(heat)
+            if self._setpoint_cool_f != float(cool):
+              self._setpoint_cool_f = float(cool)
+            if self._setpoint_heat_f != float(heat):
+              self._setpoint_heat_f = float(heat)
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.TEMP_SETPOINTS_F, {'setpoints_f': self._setpoint_cool_f})
             return True
         
         def _u_setpoints_c(heat, cool):
             """Handles setpoint interaction"""
-            self._setpoint_cool_c = float(cool)
-            self._setpoint_heat_c = float(heat)
+            if self._setpoint_cool_c != float(cool):
+              self._setpoint_cool_c = float(cool)
+            if self._setpoint_heat_c != float(heat):
+              self._setpoint_heat_c = float(heat)
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.TEMP_SETPOINTS_C, {'setpoints_c': self._setpoint_cool_c})
             return True
@@ -850,22 +856,24 @@ class HVAC(LutronEntity):
 
         def _u_fan_mode(mode):
             """Handles fan mode interaction"""
-            self._current_fan = HVAC.FanModes(int(mode)).name
+            if self._current_fan != HVAC.FanModes(int(mode)).name:
+              self._current_fan = HVAC.FanModes(int(mode)).name
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.FAN_MODE, {'current_fan': self._current_fan})
             return True
 
         def _u_call_status(mode):
             """Handles call status"""
-            self._call_status = HVAC.CallStatus(int(mode)).name
-            _LOGGER.info('################ CALL STAT')
+            if self._call_status != HVAC.CallStatus(int(mode)).name:
+              self._call_status = HVAC.CallStatus(int(mode)).name
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.CALL_STATUS, {'call_status': self._call_status})
             return True
         
         def _u_schedule_status(mode):
             """Handles schedule status"""
-            #self._call_status = HVAC.CallStatus(int(mode))
+            if self._call_status != HVAC.CallStatus(int(mode)).name:
+              self._call_status = HVAC.CallStatus(int(mode)).name
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.CALL_STATUS, {'call_status': self._call_status})
             return True

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -1023,6 +1023,10 @@ class HVAC(LutronEntity):
         """Helper to perform the actual query for call status of the thermostat."""
         self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
             HVAC.Event.CALL_STATUS.value)
+    
+    def last_status(self):
+        """Returns last cached value of status, no query is performed."""
+        return self._call_status
 
     @property
     def call_status(self):

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -1051,6 +1051,7 @@ class HVAC(LutronEntity):
     def current_mode(self, new_mode):
         """Sets the new operating mode."""
         #mode = HVAC.OperatingModes[new_mode]
+        _LOGGER.info('################ HVAC %s as %s', new_mode, self._current_mode)
         if self._current_mode == new_mode:
             return
         mode = HVAC.OperatingModes[new_mode].value

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -9,6 +9,7 @@ __copyright__ = "Copyright 2016, Dima Zavin"
 
 from enum import Enum
 import logging
+import re
 import socket
 import telnetlib
 import threading
@@ -744,8 +745,8 @@ class HVAC(LutronEntity):
     self._integration_id = integration_id
     self._lutron.register_id(HVAC._CMD_TYPE, self)
     self._temp_units = "F" if temp_units==1 else "C"
-    self._operating_modes = avail_op_modes.split()
-    self._fan_modes = avail_fan_modes.split()
+    self._operating_modes = re.split(r'\s*,\s*', avail_op_modes)
+    self._fan_modes = re.split(r'\s*,\s*', avail_fan_modes)
     self._current_fan = None
     self._current_mode = None
     self._current_temp = None
@@ -878,7 +879,7 @@ class HVAC(LutronEntity):
         Event.OPERATING_MODE, new_mode)
     self._current_mode = new_mode
 
-    
+
 class Output(LutronEntity):
   """This is the output entity in Lutron universe. This generally refers to a
   switched/dimmed load, e.g. light fixture, outlet, etc."""

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -782,15 +782,15 @@ class HVAC(LutronEntity):
         self._operating_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_op_modes)]
         self._fan_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_fan_modes)]
         self._call_status = None
-        self._schedule_status = None
-        self._current_fan = None
-        self._current_mode = None
-        self._current_temp_c = None
-        self._current_temp_f = None
-        self._setpoint_cool_c = None
-        self._setpoint_heat_c = None
-        self._setpoint_cool_f = None
-        self._setpoint_heat_f = None
+        self._schedule_status = HVAC.ScheduleStatus.SCHEDULE_UNAVAILABLE.name
+        self._current_fan = HVAC.FanModes.NO_FAN.name
+        self._current_mode = HVAC.OperatingModes.OFF.name
+        self._current_temp_c = 0.0
+        self._current_temp_f = 0
+        self._setpoint_cool_c = 0.0
+        self._setpoint_heat_c = 0.0
+        self._setpoint_cool_f = 0
+        self._setpoint_heat_f = 0
         _LOGGER.info("################ DONE INIT HVAC %s", vars(self))
 
     def __str__(self):

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -781,7 +781,7 @@ class HVAC(LutronEntity):
         self._temp_units = "F" if temp_units == 1 else "C"
         self._operating_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_op_modes)]
         self._fan_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_fan_modes)]
-        self._call_status = None
+        self._call_status = HVAC.CallStatus.OFF.name
         self._schedule_status = HVAC.ScheduleStatus.SCHEDULE_UNAVAILABLE.name
         self._current_fan = HVAC.FanModes.NO_FAN.name
         self._current_mode = HVAC.OperatingModes.OFF.name

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -869,7 +869,12 @@ class HVAC(LutronEntity):
             return True
         
         _LOGGER.info('################ HAVE IT ASSSS %s', args[0])
-        event = HVAC.Event(int(args[0]))
+        try:
+          event = HVAC.Event(int(args[0]))
+        except ValueError:
+          _LOGGER.info('################ HVAC Action Number %s not implemented', args[0])
+          return True  
+
         _LOGGER.info('################ HAVE IT A %s', event)
         handler_functions = {
           HVAC.Event.TEMP_CURRENT_F: (_u_current_temp_f, 1),

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -779,8 +779,8 @@ class HVAC(LutronEntity):
         self._integration_id = integration_id
         self._lutron.register_id(HVAC._CMD_TYPE, self)
         self._temp_units = "F" if temp_units == 1 else "C"
-        self._operating_modes = [slugify(mode) for mode in re.split(r"\s*,\s*", avail_op_modes.upper())]
-        self._fan_modes = [slugify(mode) for mode in re.split(r"\s*,\s*", avail_fan_modes.upper())]
+        self._operating_modes = [slugify(mode, separator='_', capitalize=True) for mode in re.split(r"\s*,\s*", avail_op_modes)]
+        self._fan_modes = [slugify(mode, separator='_', capitalize=True) for mode in re.split(r"\s*,\s*", avail_fan_modes)]
         self._call_status = None
         self._schedule_status = None
         self._current_fan = None

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -808,6 +808,7 @@ class HVAC(LutronEntity):
   
     def _u_operating_mode(action, mode):
       """Handles operating mode interaction"""
+      _LOGGER.info('################ HVAC self: %s as new: %s and prev: %s', self._current_mode, getattr(HVAC.OPERModes, mode).value, OPERModes.get_key(mode))
       self._current_mode = OPERModes.get_key(mode)
       self._query_waiters.notify()
       self._dispatch_event(HVAC.Event.OPERATING_MODE, {'current_mode': self._current_mode})

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -841,7 +841,6 @@ class HVAC(LutronEntity):
 
         def _u_operating_mode(action, mode):
             """Handles operating mode interaction"""
-            _LOGGER.info('################ HVAC self: %s as new: %s and prev: %s', self._current_mode, getattr(HVAC.OPERModes, mode).value, OPERModes.get_key(mode))
             self._current_mode = HVAC.OperatingModes(int(mode))
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.OPERATING_MODE, {'current_mode': self._current_mode})

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -897,6 +897,34 @@ class HVAC(LutronEntity):
     self._lutron.send(Lutron.OP_EXECUTE, HVAC._CMD_TYPE, self._integration_id,
         HVAC.Event.OPERATING_MODE, new_mode)
     self._current_mode = new_mode
+  
+
+
+  def __do_query_current_fan_mode(self):
+    """Helper to perform the actual query the current temp level of the
+    thermostat."""
+    self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
+            HVAC.Event.FAN_MODE)
+
+  def last_fan_mode(self):
+    """Returns last cached value of the temp level, no query is performed."""
+    return self._current_fan
+
+  @property
+  def current_fan_mode(self):
+    """Returns the current temp level by querying the remote controller."""
+    ev = self._query_waiters.request(self.__do_query_current_fan_mode)
+    ev.wait(1.0)
+    return self._current_fan
+
+  @current_mode.setter
+  def current_fan_mode(self, new_mode):
+    """Sets the new temp level."""
+    if self._current_fan == new_mode:
+      return
+    self._lutron.send(Lutron.OP_EXECUTE, HVAC._CMD_TYPE, self._integration_id,
+        HVAC.Event.FAN_MODE, new_mode)
+    self._current_fan = new_mode
 
 
 class Output(LutronEntity):

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -924,7 +924,7 @@ class HVAC(LutronEntity):
       ev.wait(1.0)
       return self.setpoint_heat_f
 
-    @setpoint_cool.setter
+    @setpoint_cool.setter_f
     def setpoint_cool_f(self, new_setpoint):
       """Sets the new temp level."""
       if self._setpoint_cool_f == new_setpoint:
@@ -933,7 +933,7 @@ class HVAC(LutronEntity):
           str(HVAC.Event.TEMP_SETPOINTS_F.value), str(self._setpoint_heat_f), str(new_setpoint))
       self._setpoint_cool_f = new_setpoint
   
-    @setpoint_heat.setter
+    @setpoint_heat.setter_f
     def setpoint_heat_f(self, new_setpoint):
       """Sets the new temp level."""
       if self._setpoint_heat_f == new_setpoint:
@@ -970,7 +970,7 @@ class HVAC(LutronEntity):
       ev.wait(1.0)
       return self.setpoint_heat_c
 
-    @setpoint_cool.setter
+    @setpoint_cool.setter_c
     def setpoint_cool_c(self, new_setpoint):
       """Sets the new temp level."""
       if self._setpoint_cool_c == new_setpoint:
@@ -979,7 +979,7 @@ class HVAC(LutronEntity):
           str(HVAC.Event.TEMP_SETPOINTS_C.value), str(self._setpoint_heat_c), str(new_setpoint))
       self._setpoint_cool_c = new_setpoint
   
-    @setpoint_heat.setter
+    @setpoint_heat.setter_c
     def setpoint_heat_c(self, new_setpoint):
       """Sets the new temp level."""
       if self._setpoint_heat_c == new_setpoint:

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -892,12 +892,13 @@ class HVAC(LutronEntity):
   @current_mode.setter
   def current_mode(self, new_mode):
     """Sets the new temp level."""
-    if self._current_mode == new_mode:
+    mode = getattr(HVAC.OPERModes, new_mode).value
+    if self._current_mode == mode:
       return
-    _LOGGER.info('################ HVAC %s', str(HVAC.Event.OPERATING_MODE.value))
+    _LOGGER.info('################ HVAC %s as %s', str(HVAC.Event.OPERATING_MODE.value), getattr(HVAC.OPERModes, new_mode).value)
     self._lutron.send(Lutron.OP_EXECUTE, HVAC._CMD_TYPE, self._integration_id,
-        HVAC.Event.OPERATING_MODE, new_mode)
-    self._current_mode = new_mode
+        str(HVAC.Event.OPERATING_MODE.value), mode)
+    self._current_mode = mode
   
 
 

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -842,7 +842,7 @@ class HVAC(LutronEntity):
 
         def _u_operating_mode(mode):
             """Handles operating mode interaction"""
-            self._current_mode = HVAC.OperatingModes(int(mode))
+            self._current_mode = HVAC.OperatingModes(int(mode)).name
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.OPERATING_MODE, {'current_mode': self._current_mode})
             return True

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -270,7 +270,9 @@ class LutronXmlDbParser(object):
     for hvac_xml in hvac_area.iter('HVAC'):
       _LOGGER.info('################ FOUND HVAC')
       hvac = self._parse_hvac(hvac_xml)
+      _LOGGER.info('################ FOUND HVAC %s', vars(hvac))
       self.hvacs.append(hvac)
+
     return True
   
   def _parse_hvac(self, hvac_xml):
@@ -565,6 +567,7 @@ class Lutron(object):
     parser = LutronXmlDbParser(lutron=self, xml_db_str=xml_db)
     assert(parser.parse())     # throw our own exception
     self._areas = parser.areas
+    self._hvacs = parser.hvacs
     self._name = parser.project_name
 
     _LOGGER.info('Found Lutron projection: %s, %d areas' % (
@@ -927,11 +930,6 @@ class Output(LutronEntity):
     self._lutron.send(Lutron.OP_EXECUTE, Output._CMD_TYPE, self._integration_id,
         Output._ACTION_ZONE_LEVEL, "%.2f" % new_level)
     self._level = new_level
-
-## At some later date, we may want to also specify fade and delay times
-#  def set_level(self, new_level, fade_time, delay):
-#    self._lutron.send(Lutron.OP_EXECUTE, Output._CMD_TYPE,
-#        Output._ACTION_ZONE_LEVEL, new_level, fade_time, delay)
 
   @property
   def watts(self):

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -991,9 +991,9 @@ class HVAC(LutronEntity):
     def __do_query_current_temp(self):
         """Helper to perform the actual query the current temp level."""
         self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
-            HVAC.Event.TEMP_CURRENT_F)
+            HVAC.Event.TEMP_CURRENT_F.value)
         self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
-            HVAC.Event.TEMP_CURRENT_C)
+            HVAC.Event.TEMP_CURRENT_C.value)
 
     def last_temp_f(self):
         """Returns last cached value of the temp level, no query is performed."""
@@ -1020,7 +1020,7 @@ class HVAC(LutronEntity):
     def __query_call_status(self):
         """Helper to perform the actual query for call status of the thermostat."""
         self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
-            HVAC.Event.CALL_STATUS)
+            HVAC.Event.CALL_STATUS.value)
 
     @property
     def call_status(self):
@@ -1032,7 +1032,7 @@ class HVAC(LutronEntity):
     def __do_query_current_mode(self):
         """Helper to perform the actual query of the current mode"""
         self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
-            HVAC.Event.OPERATING_MODE)
+            HVAC.Event.OPERATING_MODE.value)
 
     def last_mode(self):
         """Returns last cached value of the temp level, no query is performed."""
@@ -1060,7 +1060,7 @@ class HVAC(LutronEntity):
     def __do_query_current_fan_mode(self):
         """Helper to perform the actual query of the fan mode"""
         self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
-            HVAC.Event.FAN_MODE)
+            HVAC.Event.FAN_MODE.value)
 
     def last_fan_mode(self):
         """Returns last cached fan mode, no query is performed."""
@@ -1091,7 +1091,7 @@ class HVAC(LutronEntity):
     def __do_query_sch_stat(self):
       """Helper to perform the actual query"""
       self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
-              HVAC.Event.SCHEDULE_STATUS)
+              HVAC.Event.SCHEDULE_STATUS.value)
       
     @property
     def schedule_status(self):

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -815,7 +815,7 @@ class HVAC(LutronEntity):
             if self._current_temp_f != float(temp):
               self._current_temp_f = float(temp)
             self._query_waiters.notify()
-            self._dispatch_event(HVAC.Event.TEMP_CURRENT_F, {'current_temp_f': self._current_temp})
+            self._dispatch_event(HVAC.Event.TEMP_CURRENT_F, {'current_temp_f': self._current_temp_f})
             return True
         
         def _u_current_temp_c(temp):
@@ -823,7 +823,7 @@ class HVAC(LutronEntity):
             if self._current_temp_c != float(temp):
               self._current_temp_c = float(temp)
             self._query_waiters.notify()
-            self._dispatch_event(HVAC.Event.TEMP_CURRENT_C, {'current_temp_c': self._current_temp})
+            self._dispatch_event(HVAC.Event.TEMP_CURRENT_C, {'current_temp_c': self._current_temp_f})
             return True
 
         def _u_setpoints_f(heat, cool):

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -1098,9 +1098,10 @@ class HVAC(LutronEntity):
     @property
     def current_fan_mode(self):
         """Returns the current fan mode by querying the remote controller."""
+        _LOGGER.info('################ 1RETURNING HVAC FAN MODE %s ', self._current_fan)
         ev = self._query_waiters.request(self.__do_query_current_fan_mode)
         ev.wait(1.0)
-        _LOGGER.info('################ RETURNING HVAC FAN MODE %s ', self._current_fan)
+        _LOGGER.info('################ 2RETURNING HVAC FAN MODE %s ', self._current_fan)
         return self._current_fan
 
     @current_mode.setter

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -222,7 +222,6 @@ class LutronXmlDbParser(object):
     self.hvacs = []
     self._occupancy_groups = {}
     self.project_name = None
-    
 
   def parse(self):
     """Main entrypoint into the parser. It interprets and creates all the
@@ -1121,7 +1120,6 @@ class Output(LutronEntity):
 #    self._lutron.send(Lutron.OP_EXECUTE, Output._CMD_TYPE,
 #        Output._ACTION_ZONE_LEVEL, new_level, fade_time, delay)
 
-
   @property
   def watts(self):
     """Returns the configured maximum wattage for this output (not an actual
@@ -1488,7 +1486,7 @@ class MotionSensor(LutronEntity):
   def id(self):
     """The integration id"""
     return self._integration_id
-  
+
   @property
   def legacy_uuid(self):
     return str(self.id)

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -690,13 +690,13 @@ class HVAC(LutronEntity):
 
   class FANModes(Enum):
     """Possible fan modes"""
-    AUTO = '1'
-    ON = '2'
+    Auto = '1'
+    On = '2'
     CYCLER = '3'
     NO_FAN = '4'
-    HIGH = '5'
-    MEDIUM = '6'
-    LOW = '7'
+    High = '5'
+    Medium = '6'
+    Low = '7'
     TOP = '8'
 
     @classmethod
@@ -708,14 +708,14 @@ class HVAC(LutronEntity):
   
   class OPERModes(Enum):
     """Possible operating modes"""
-    OFF = '1'
-    HEAT = '2'
-    COOL = '3'
-    AUTO = '4'
+    Off = '1'
+    Heat = '2'
+    Cool = '3'
+    Auto = '4'
     EM_HEAT = '5'
-    LOCKED = '6'
-    FAN = '7'
-    DRY = '8'
+    Locked = '6'
+    Fan = '7'
+    Dry = '8'
 
     @classmethod
     def get_key(cls, value):
@@ -850,6 +850,35 @@ class HVAC(LutronEntity):
         Event.TEMP_CURRENT_F, "%.2f" % new_temp)
     self._current_temp = new_temp
 
+
+
+  def __do_query_current_mode(self):
+    """Helper to perform the actual query the current temp level of the
+    thermostat."""
+    self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
+            Event.OPERATING_MODE)
+
+  def last_mode(self):
+    """Returns last cached value of the temp level, no query is performed."""
+    return self._current_mode
+
+  @property
+  def current_mode(self):
+    """Returns the current temp level by querying the remote controller."""
+    ev = self._query_waiters.request(self.__do_query_current_mode)
+    ev.wait(1.0)
+    return self._current_mode
+
+  @current_mode.setter
+  def current_mode(self, new_mode):
+    """Sets the new temp level."""
+    if self._current_mode == new_mode:
+      return
+    self._lutron.send(Lutron.OP_EXECUTE, HVAC._CMD_TYPE, self._integration_id,
+        Event.OPERATING_MODE, new_mode)
+    self._current_mode = new_mode
+
+    
 class Output(LutronEntity):
   """This is the output entity in Lutron universe. This generally refers to a
   switched/dimmed load, e.g. light fixture, outlet, etc."""

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -456,6 +456,11 @@ class Lutron(object):
   def areas(self):
     """Return the areas that were discovered for this Lutron controller."""
     return self._areas
+  
+  @property
+  def hvacs(self):
+    """Return the hvacs that were discovered for this Lutron controller."""
+    return self._hvacs
 
   def set_guid(self, guid):
     self._guid = guid

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -848,7 +848,7 @@ class HVAC(LutronEntity):
     if self._current_temp == new_temp:
       return
     self._lutron.send(Lutron.OP_EXECUTE, HVAC._CMD_TYPE, self._integration_id,
-        Event.TEMP_CURRENT_F, "%.2f" % new_temp)
+        HVAC.Event.TEMP_CURRENT_F, "%.2f" % new_temp)
     self._current_temp = new_temp
 
 
@@ -857,7 +857,7 @@ class HVAC(LutronEntity):
     """Helper to perform the actual query the current temp level of the
     thermostat."""
     self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
-            Event.OPERATING_MODE)
+            HVAC.Event.OPERATING_MODE)
 
   def last_mode(self):
     """Returns last cached value of the temp level, no query is performed."""
@@ -876,7 +876,7 @@ class HVAC(LutronEntity):
     if self._current_mode == new_mode:
       return
     self._lutron.send(Lutron.OP_EXECUTE, HVAC._CMD_TYPE, self._integration_id,
-        Event.OPERATING_MODE, new_mode)
+        HVAC.Event.OPERATING_MODE, new_mode)
     self._current_mode = new_mode
 
 

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -288,6 +288,10 @@ class LutronXmlDbParser(object):
       'temp_units': int(hvac_xml.get('TemperatureUnits')),
       'avail_op_modes': hvac_xml.get('AvailableOperatingModes'),
       'avail_fan_modes': hvac_xml.get('AvailableFanModes'),
+      'min_temp_cool': hvac_xml.get('MinCoolSet'),
+      'max_temp_cool': hvac_xml.get('MaxCoolSet'),
+      'min_temp_heat': hvac_xml.get('MinHeatSet'),
+      'max_temp_heat': hvac_xml.get('MaxHeatSet'),
     }
     return HVAC(self._lutron, **kwargs)
 
@@ -772,6 +776,10 @@ class HVAC(LutronEntity):
         temp_units,
         avail_op_modes,
         avail_fan_modes,
+        min_temp_cool,
+        max_temp_cool,
+        min_temp_heat,
+        max_temp_heat,
     ):
         """Initializes the HVAC controller."""
         super(HVAC, self).__init__(lutron, name, uuid)
@@ -781,6 +789,10 @@ class HVAC(LutronEntity):
         self._temp_units = "F" if temp_units == 1 else "C"
         self._operating_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_op_modes)]
         self._fan_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_fan_modes)]
+        self._min_temp_cool = min_temp_cool
+        self._max_temp_cool = max_temp_cool
+        self._min_temp_heat = min_temp_heat
+        self._max_temp_heat = max_temp_heat
         self._call_status = HVAC.CallStatus.OFF.name
         self._schedule_status = HVAC.ScheduleStatus.SCHEDULE_UNAVAILABLE.name
         self._current_fan = HVAC.FanModes.NO_FAN.name

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -216,10 +216,11 @@ class LutronXmlDbParser(object):
   def __init__(self, lutron, xml_db_str):
     """Initializes the XML parser, takes the raw XML data as string input."""
     self._lutron = lutron
-    self._occupancy_groups = {}
+    
     self._xml_db_str = xml_db_str
     self.areas = []
     self.hvacs = []
+    self._occupancy_groups = {}
     self.project_name = None
     
 
@@ -572,7 +573,7 @@ class Lutron(object):
     self._hvacs = parser.hvacs
     self._name = parser.project_name
 
-    _LOGGER.info('Found Lutron projection: %s, %d areas' % (
+    _LOGGER.info('Found Lutron project: %s, %d areas' % (
         self._name, len(self.areas)))
 
     if cache_path and loaded_from == 'repeater':
@@ -1182,10 +1183,6 @@ class KeypadComponent(LutronEntity):
     events. This is different from KeypadComponent.number because this property
     is only used for interfacing with the controller."""
     return self._component_num
-  
-  @property
-  def legacy_uuid(self):
-    return '%d-%d' % (self._keypad.id, self._component_num)
 
   @property
   def legacy_uuid(self):
@@ -1392,10 +1389,6 @@ class Keypad(LutronEntity):
   def id(self):
     """The integration id"""
     return self._integration_id
-  
-  @property
-  def legacy_uuid(self):
-    return '%d-0' % self.id
 
   @property
   def legacy_uuid(self):
@@ -1447,7 +1440,6 @@ class PowerSource(Enum):
   BATTERY = 1
   EXTERNAL = 2
 
-
 class BatteryStatus(Enum):
   """Enum values representing battery state, reported by queries to
   battery-powered devices."""
@@ -1497,10 +1489,6 @@ class MotionSensor(LutronEntity):
     """The integration id"""
     return self._integration_id
   
-  @property
-  def legacy_uuid(self):
-    return str(self.id)
-
   @property
   def legacy_uuid(self):
     return str(self.id)

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -288,6 +288,7 @@ class LutronXmlDbParser(object):
       'temp_units': int(hvac_xml.get('TemperatureUnits')),
       'avail_op_modes': hvac_xml.get('AvailableOperatingModes'),
       'avail_fan_modes': hvac_xml.get('AvailableFanModes'),
+      'avail_misc_features': hvac_xml.get('AvailableMiscFeatures'),
       'min_temp_cool': hvac_xml.get('MinCoolSet'),
       'max_temp_cool': hvac_xml.get('MaxCoolSet'),
       'min_temp_heat': hvac_xml.get('MinHeatSet'),
@@ -493,7 +494,7 @@ class Lutron(object):
     if not isinstance(obj, LutronEntity):
       raise InvalidSubscription("Subscription target not a LutronEntity")
     _LOGGER.warning("DEPRECATED: Subscribing via Lutron.subscribe is obsolete. "
-                    "Please use LutronEntity.subscribe")
+                    "Please use LutronEntity.ccccccccc")
     if obj not in self._legacy_subscribers:
       self._legacy_subscribers[obj] = handler
       obj.subscribe(self._dispatch_legacy_subscriber, None)
@@ -776,6 +777,7 @@ class HVAC(LutronEntity):
         temp_units,
         avail_op_modes,
         avail_fan_modes,
+        avail_misc_features,
         min_temp_cool,
         max_temp_cool,
         min_temp_heat,
@@ -789,6 +791,7 @@ class HVAC(LutronEntity):
         self._temp_units = "F" if temp_units == 1 else "C"
         self._operating_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_op_modes)]
         self._fan_modes = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_fan_modes)]
+        self._avail_misc_features = [slugify(mode, separator='_').upper() for mode in re.split(r"\s*,\s*", avail_misc_features)]
         self._min_temp_cool = min_temp_cool
         self._max_temp_cool = max_temp_cool
         self._min_temp_heat = min_temp_heat

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -913,14 +913,14 @@ class HVAC(LutronEntity):
     @property
     def setpoint_cool_f(self):
       """Returns the current temp level by querying the remote controller."""
-      ev = self._query_waiters.request(self.__do_query_setpoint)
+      ev = self._query_waiters.request(self.__do_query_setpoint_f)
       ev.wait(1.0)
       return self._setpoint_cool_f
     
     @property
     def setpoint_heat_f(self):
       """Returns the current temp level by querying the remote controller."""
-      ev = self._query_waiters.request(self.__do_query_setpoint)
+      ev = self._query_waiters.request(self.__do_query_setpoint_f)
       ev.wait(1.0)
       return self.setpoint_heat_f
 
@@ -959,14 +959,14 @@ class HVAC(LutronEntity):
     @property
     def setpoint_cool_c(self):
       """Returns the current temp level by querying the remote controller."""
-      ev = self._query_waiters.request(self.__do_query_setpoint)
+      ev = self._query_waiters.request(self.__do_query_setpoint_c)
       ev.wait(1.0)
       return self._setpoint_cool_c
     
     @property
     def setpoint_heat_c(self):
       """Returns the current temp level by querying the remote controller."""
-      ev = self._query_waiters.request(self.__do_query_setpoint)
+      ev = self._query_waiters.request(self.__do_query_setpoint_c)
       ev.wait(1.0)
       return self.setpoint_heat_c
 

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -732,16 +732,16 @@ class HVAC(LutronEntity):
 
   class Event(LutronEvent,EnumWithReverseMapping):
     """Output events that can be generated."""
-    TEMP_CURRENT_F = 1
-    TEMP_SETPOINTS_F = 2
-    OPERATING_MODE = 3
-    FAN_MODE = 4
-    ECO_MODE = 5
-    ECO_OFFSET = 6
-    SYSTEM_MODE = 11
-    CALL_STATUS = 14
-    TEMP_CURRENT_C = 15
-    TEMP_SETPOINTS_C = 16
+    TEMP_CURRENT_F = '1'
+    TEMP_SETPOINTS_F = '2'
+    OPERATING_MODE = '3'
+    FAN_MODE = '4'
+    ECO_MODE = '5'
+    ECO_OFFSET = '6'
+    SYSTEM_MODE = '11'
+    CALL_STATUS = '14'
+    TEMP_CURRENT_C = '15'
+    TEMP_SETPOINTS_C = '16'
 
   def __init__(self, lutron, name, integration_id, uuid, temp_units, avail_op_modes, avail_fan_modes):
     """Initializes the Output."""

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -16,6 +16,7 @@ import telnetlib
 import threading
 import time
 
+from slugify import slugify
 from typing import Any, Callable, Dict, Type
 
 _LOGGER = logging.getLogger(__name__)
@@ -719,7 +720,7 @@ class HVAC(LutronEntity):
         HEAT = 2
         COOL = 3
         AUTO = 4
-        EM_HEAT = 5
+        EMERGENCY_HEAT = 5
         LOCKED = 6
         FAN = 7
         DRY = 8
@@ -772,14 +773,14 @@ class HVAC(LutronEntity):
         avail_op_modes,
         avail_fan_modes,
     ):
-        """Initializes the Output."""
+        """Initializes the HVAC controller."""
         super(HVAC, self).__init__(lutron, name, uuid)
         self._query_waiters = _RequestHelper()
         self._integration_id = integration_id
         self._lutron.register_id(HVAC._CMD_TYPE, self)
         self._temp_units = "F" if temp_units == 1 else "C"
-        self._operating_modes = re.split(r"\s*,\s*", avail_op_modes.upper())
-        self._fan_modes = re.split(r"\s*,\s*", avail_fan_modes.upper())
+        self._operating_modes = [slugify(mode) for mode in re.split(r"\s*,\s*", avail_op_modes.upper())]
+        self._fan_modes = [slugify(mode) for mode in re.split(r"\s*,\s*", avail_fan_modes.upper())]
         self._call_status = None
         self._schedule_status = None
         self._current_fan = None

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -917,8 +917,9 @@ class HVAC(LutronEntity):
 
         def _u_eco_mode(mode):
             """Handles eco mode status"""
-            if self._eco_mode != bool(int(mode)):
-              self._eco_mode = bool(int(mode))
+            mode = int(mode)-1
+            if self._eco_mode != bool(mode):
+              self._eco_mode = bool(mode)
               self._query_waiters.notify()
               self._dispatch_event(HVAC.Event.ECO_MODE, {'eco_mode': self._eco_mode})
               return True
@@ -1144,7 +1145,7 @@ class HVAC(LutronEntity):
         if self._eco_mode == new_mode:
             return
         self._lutron.send(Lutron.OP_EXECUTE, HVAC._CMD_TYPE, self._integration_id,
-        str(HVAC.Event.ECO_MODE.value), str(int(new_mode)))
+        str(HVAC.Event.ECO_MODE.value), str(int(new_mode)+1))
         self._eco_mode = new_mode
 
     def __do_query_current_fan(self):

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -810,21 +810,21 @@ class HVAC(LutronEntity):
         """Handles an event update for this object, e.g. temp level change."""
         _LOGGER.debug("handle_update %d -- %s" % (self._integration_id, args))
 
-        def _u_current_temp_f(action, temp):
+        def _u_current_temp_f(temp):
             """Handles current temp interaction"""
             self._current_temp_f = float(temp)
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.TEMP_CURRENT_F, {'current_temp_f': self._current_temp})
             return True
         
-        def _u_current_temp_c(action, temp):
+        def _u_current_temp_c(temp):
             """Handles current temp interaction"""
             self._current_temp_c = float(temp)
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.TEMP_CURRENT_C, {'current_temp_c': self._current_temp})
             return True
 
-        def _u_setpoints_f(action, heat, cool):
+        def _u_setpoints_f(heat, cool):
             """Handles setpoint interaction"""
             self._setpoint_cool_f = float(cool)
             self._setpoint_heat_f = float(heat)
@@ -832,7 +832,7 @@ class HVAC(LutronEntity):
             self._dispatch_event(HVAC.Event.TEMP_SETPOINTS_F, {'setpoints_f': self._setpoint_cool_f})
             return True
         
-        def _u_setpoints_c(action, heat, cool):
+        def _u_setpoints_c(heat, cool):
             """Handles setpoint interaction"""
             self._setpoint_cool_c = float(cool)
             self._setpoint_heat_c = float(heat)
@@ -840,30 +840,30 @@ class HVAC(LutronEntity):
             self._dispatch_event(HVAC.Event.TEMP_SETPOINTS_C, {'setpoints_c': self._setpoint_cool_c})
             return True
 
-        def _u_operating_mode(action, mode):
+        def _u_operating_mode(mode):
             """Handles operating mode interaction"""
             self._current_mode = HVAC.OperatingModes(int(mode))
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.OPERATING_MODE, {'current_mode': self._current_mode})
             return True
 
-        def _u_fan_mode(action, mode):
+        def _u_fan_mode(mode):
             """Handles fan mode interaction"""
             self._current_fan = HVAC.FanModes(int(mode))
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.FAN_MODE, {'current_fan': self._current_fan})
             return True
 
-        def _u_call_status(action, mode):
+        def _u_call_status(mode):
             """Handles call status"""
             self._call_status = HVAC.CallStatus(int(mode))
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.CALL_STATUS, {'call_status': self._call_status})
             return True
         
-        def _u_schedule_status(action, mode):
+        def _u_schedule_status(mode):
             """Handles schedule status"""
-            self._call_status = HVAC.CallStatus(int(mode))
+            #self._call_status = HVAC.CallStatus(int(mode))
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.CALL_STATUS, {'call_status': self._call_status})
             return True

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -842,14 +842,15 @@ class HVAC(LutronEntity):
 
         def _u_operating_mode(mode):
             """Handles operating mode interaction"""
-            self._current_mode = HVAC.OperatingModes(int(mode)).name
+            if self._current_mode != HVAC.OperatingModes(int(mode)).name:
+              self._current_mode = HVAC.OperatingModes(int(mode)).name
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.OPERATING_MODE, {'current_mode': self._current_mode})
             return True
 
         def _u_fan_mode(mode):
             """Handles fan mode interaction"""
-            self._current_fan = HVAC.FanModes(int(mode))
+            self._current_fan = HVAC.FanModes(int(mode)).name
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.FAN_MODE, {'current_fan': self._current_fan})
             return True
@@ -874,7 +875,7 @@ class HVAC(LutronEntity):
           event = HVAC.Event(int(args[0]))
         except ValueError:
           _LOGGER.info('################ HVAC Action Number %s not implemented', args[0])
-          return True  
+          return False  
 
         _LOGGER.info('################ HAVE IT A %s', event)
         handler_functions = {

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -869,7 +869,7 @@ class HVAC(LutronEntity):
             return True
         
         _LOGGER.info('################ HAVE IT ASSSS %s', args[0])
-        event = HVAC.Event.get_key(int(args[0]))
+        event = HVAC.Event(int(args[0]))
         _LOGGER.info('################ HAVE IT A %s', event)
         handler_functions = {
           HVAC.Event.TEMP_CURRENT_F: (_u_current_temp_f, 1),

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -827,8 +827,8 @@ class HVAC(LutronEntity):
       self._query_waiters.notify()
       self._dispatch_event(HVAC.Event.CALL_STATUS, {'call_status': self._call_status})
       return True
-
-    event = getattr(HVAC.Event, args[0]).value
+    _LOGGER.info('################ HAVE IT ASSSS %s', args[0])
+    event = HVAC.Event.get_key(args[0])
     _LOGGER.info('################ HAVE IT A %s', event)
     handler_functions = {
         HVAC.Event.TEMP_CURRENT_F: (_u_current_temp, 1),

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -894,6 +894,7 @@ class HVAC(LutronEntity):
     """Sets the new temp level."""
     if self._current_mode == new_mode:
       return
+    _LOGGER.info('################ HVAC %s', str(HVAC.Event.OPERATING_MODE))
     self._lutron.send(Lutron.OP_EXECUTE, HVAC._CMD_TYPE, self._integration_id,
         HVAC.Event.OPERATING_MODE, new_mode)
     self._current_mode = new_mode

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -730,7 +730,7 @@ class HVAC(LutronEntity):
     EmgHeat = '9'
     Dry = '10'
 
-  class Event(LutronEvent):
+  class Event(LutronEvent,EnumWithReverseMapping):
     """Output events that can be generated."""
     TEMP_CURRENT_F = 1
     TEMP_SETPOINTS_F = 2

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -894,7 +894,7 @@ class HVAC(LutronEntity):
     """Sets the new temp level."""
     if self._current_mode == new_mode:
       return
-    _LOGGER.info('################ HVAC %s', str(HVAC.Event.OPERATING_MODE))
+    _LOGGER.info('################ HVAC %s', str(HVAC.Event.OPERATING_MODE.value))
     self._lutron.send(Lutron.OP_EXECUTE, HVAC._CMD_TYPE, self._integration_id,
         HVAC.Event.OPERATING_MODE, new_mode)
     self._current_mode = new_mode

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -857,6 +857,7 @@ class HVAC(LutronEntity):
         def _u_call_status(mode):
             """Handles call status"""
             self._call_status = HVAC.CallStatus(int(mode))
+            _LOGGER.info('################ CALL STAT')
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.CALL_STATUS, {'call_status': self._call_status})
             return True
@@ -891,6 +892,7 @@ class HVAC(LutronEntity):
             handler, num_args = handler_functions[event]
             if num_args == 1:
                 handler(args[1])
+                _LOGGER.info('################ ONE %s', args[1])
             elif num_args == 2:
                 handler(args[1], args[2])
 

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -885,10 +885,10 @@ class HVAC(LutronEntity):
         
         def _u_schedule_status(mode):
             """Handles schedule status"""
-            if self._call_status != HVAC.CallStatus(int(mode)).name:
-              self._call_status = HVAC.CallStatus(int(mode)).name
+            if self._schedule_status != HVAC.ScheduleStatus(int(mode)).name:
+              self._schedule_status = HVAC.ScheduleStatus(int(mode)).name
             self._query_waiters.notify()
-            self._dispatch_event(HVAC.Event.CALL_STATUS, {'call_status': self._call_status})
+            self._dispatch_event(HVAC.Event.SCHEDULE_STATUS, {'schedule_status': self._schedule_status})
             return True
         
         _LOGGER.info('################ HAVE IT ASSSS %s', args[0])

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -856,7 +856,7 @@ class HVAC(LutronEntity):
 
         def _u_call_status(mode):
             """Handles call status"""
-            self._call_status = HVAC.CallStatus(int(mode))
+            self._call_status = HVAC.CallStatus(int(mode)).name
             _LOGGER.info('################ CALL STAT')
             self._query_waiters.notify()
             self._dispatch_event(HVAC.Event.CALL_STATUS, {'call_status': self._call_status})

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -449,6 +449,7 @@ class Lutron(object):
     self._ids = {}
     self._legacy_subscribers = {}
     self._areas = []
+    self._hvacs = []
     self._guid = None
 
   @property

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -779,8 +779,8 @@ class HVAC(LutronEntity):
         self._integration_id = integration_id
         self._lutron.register_id(HVAC._CMD_TYPE, self)
         self._temp_units = "F" if temp_units == 1 else "C"
-        self._operating_modes = [slugify(mode, separator='_', capitalize=True) for mode in re.split(r"\s*,\s*", avail_op_modes)]
-        self._fan_modes = [slugify(mode, separator='_', capitalize=True) for mode in re.split(r"\s*,\s*", avail_fan_modes)]
+        self._operating_modes = [slugify(mode.upper(), separator='_') for mode in re.split(r"\s*,\s*", avail_op_modes)]
+        self._fan_modes = [slugify(mode.upper(), separator='_') for mode in re.split(r"\s*,\s*", avail_fan_modes)]
         self._call_status = None
         self._schedule_status = None
         self._current_fan = None

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -214,11 +214,12 @@ class LutronXmlDbParser(object):
   def __init__(self, lutron, xml_db_str):
     """Initializes the XML parser, takes the raw XML data as string input."""
     self._lutron = lutron
+    self._occupancy_groups = {}
     self._xml_db_str = xml_db_str
     self.areas = []
-    self._occupancy_groups = {}
-    self.project_name = None
     self.hvacs = []
+    self.project_name = None
+    
 
   def parse(self):
     """Main entrypoint into the parser. It interprets and creates all the
@@ -652,7 +653,7 @@ class LutronEntity(object):
     """Subscribes to events from this entity.
 
     handler: A callable object that takes the following arguments (in order)
-             obj: the LutrongEntity object that generated the event
+             obj: the LutronEntity object that generated the event
              context: user-supplied (to subscribe()) context object
              event: the LutronEvent that was generated.
              params: a dict of event-specific parameters
@@ -684,11 +685,18 @@ class HVAC(LutronEntity):
         Params:
           level: new output level (float)
     """
-    TEMP_CHANGED = 2
-    MODE_CHANGED = 3
-    FANM_CHANGED = 4
+    TEMP_CURRENT_F = 1 #new
+    TEMP_SETPOINT_F = 2  #TEMP_CHANGED = 2
+    OPERATING_MODE = 3  #MODE_CHANGED = 3
+    FAN_MODE = 4  #FANM_CHANGED = 4
+    ECO_MODE = 5
+    ECO_OFFSET = 6
+    SYSTEM_MODE = 11
+    CALL_STATUS = 14
+    TEMP_CURRENT_C = 15
+    TEMP_SETPOINT_C = 16
 
-  def __init__(self, lutron, name, integration_id, uuid):
+  def __init__(self, lutron, name, integration_id, uuid, temp_units, avail_op_modes, avail_fan_modes):
     """Initializes the Output."""
     super(HVAC, self).__init__(lutron, name, uuid)
     self._query_waiters = _RequestHelper()
@@ -720,7 +728,7 @@ class HVAC(LutronEntity):
         self._integration_id, self._name, state, level))
     self._level = level
     self._query_waiters.notify()
-    self._dispatch_event(HVAC.Event.TEMP_CHANGED, {'level': self._level})
+    self._dispatch_event(HVAC.Event.TEMP_SETPOINT_F, {'level': self._level})
     return True
 
   def __do_query_level(self):

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -896,6 +896,98 @@ class HVAC(LutronEntity):
 
         return True
 
+    def last_setpoint_cool_f(self):
+      """Returns last cached value of the temp level, no query is performed."""
+      return self._setpoint_cool_f
+
+    def last_setpoint_heat_f(self):
+      """Returns last cached value of the temp level, no query is performed."""
+      return self._setpoint_heat_f
+    
+    def __do_query_setpoint_f(self):
+      """Helper to perform the actual query the current temp level of the
+      thermostat. For pure on/off loads the result is either 0.0 or 100.0."""
+      self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
+              str(HVAC.Event.TEMP_SETPOINTS_F.value))
+
+    @property
+    def setpoint_cool_f(self):
+      """Returns the current temp level by querying the remote controller."""
+      ev = self._query_waiters.request(self.__do_query_setpoint)
+      ev.wait(1.0)
+      return self._setpoint_cool_f
+    
+    @property
+    def setpoint_heat_f(self):
+      """Returns the current temp level by querying the remote controller."""
+      ev = self._query_waiters.request(self.__do_query_setpoint)
+      ev.wait(1.0)
+      return self.setpoint_heat_f
+
+    @setpoint_cool.setter
+    def setpoint_cool_f(self, new_setpoint):
+      """Sets the new temp level."""
+      if self._setpoint_cool_f == new_setpoint:
+        return
+      self._lutron.send(Lutron.OP_EXECUTE, HVAC._CMD_TYPE, self._integration_id,
+          str(HVAC.Event.TEMP_SETPOINTS_F.value), str(self._setpoint_heat_f), str(new_setpoint))
+      self._setpoint_cool_f = new_setpoint
+  
+    @setpoint_heat.setter
+    def setpoint_heat_f(self, new_setpoint):
+      """Sets the new temp level."""
+      if self._setpoint_heat_f == new_setpoint:
+        return
+      self._lutron.send(Lutron.OP_EXECUTE, HVAC._CMD_TYPE, self._integration_id,
+          str(HVAC.Event.TEMP_SETPOINTS_F.value), str(new_setpoint), str(self._setpoint_cool_f))
+      self._setpoint_heat_f = new_setpoint
+
+    def last_setpoint_cool_c(self):
+      """Returns last cached value of the temp level, no query is performed."""
+      return self._setpoint_cool_c
+    
+    def last_setpoint_heat_c(self):
+      """Returns last cached value of the temp level, no query is performed."""
+      return self._setpoint_heat_c
+    
+    def __do_query_setpoint_c(self):
+      """Helper to perform the actual query the current temp level of the
+      thermostat. For pure on/off loads the result is either 0.0 or 100.0."""
+      self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,
+              str(HVAC.Event.TEMP_SETPOINTS_C.value))
+
+    @property
+    def setpoint_cool_c(self):
+      """Returns the current temp level by querying the remote controller."""
+      ev = self._query_waiters.request(self.__do_query_setpoint)
+      ev.wait(1.0)
+      return self._setpoint_cool_c
+    
+    @property
+    def setpoint_heat_c(self):
+      """Returns the current temp level by querying the remote controller."""
+      ev = self._query_waiters.request(self.__do_query_setpoint)
+      ev.wait(1.0)
+      return self.setpoint_heat_c
+
+    @setpoint_cool.setter
+    def setpoint_cool_c(self, new_setpoint):
+      """Sets the new temp level."""
+      if self._setpoint_cool_c == new_setpoint:
+        return
+      self._lutron.send(Lutron.OP_EXECUTE, HVAC._CMD_TYPE, self._integration_id,
+          str(HVAC.Event.TEMP_SETPOINTS_C.value), str(self._setpoint_heat_c), str(new_setpoint))
+      self._setpoint_cool_c = new_setpoint
+  
+    @setpoint_heat.setter
+    def setpoint_heat_c(self, new_setpoint):
+      """Sets the new temp level."""
+      if self._setpoint_heat_c == new_setpoint:
+        return
+      self._lutron.send(Lutron.OP_EXECUTE, HVAC._CMD_TYPE, self._integration_id,
+          str(HVAC.Event.TEMP_SETPOINTS_C.value), str(new_setpoint), str(self._setpoint_cool_c))
+      self._setpoint_heat_c = new_setpoint
+
     def __do_query_current_temp(self):
         """Helper to perform the actual query the current temp level."""
         self._lutron.send(Lutron.OP_QUERY, HVAC._CMD_TYPE, self._integration_id,


### PR DESCRIPTION
This PR aims to add support for basic HVAC controls.

enums are used to store friendly text instead of integers so that applications utilizing this code do not need to have a dictionary to know what is happening.  Similarly, those applications will write the values as the strings.

due to the number of attributes related to this object, the handle_update function has several helper functions and an attempt was made to streamline that code.