### PR TITLE
update output types to prevent switches becoming lights in HA

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -779,7 +779,7 @@ class Output(LutronEntity):
   @property
   def is_dimmable(self):
     """Returns a boolean of whether or not the output is dimmable."""
-    return self.type not in ('NON_DIM', 'NON_DIM_INC', 'NON_DIM_ELV', 'EXHAUST_FAN_TYPE', 'RELAY_LIGHTING') and not self.type.startswith('CCO_')
+    return not self.type.startswith('NON_DI') and not self.type.startswith('CCO_') and not self.type.startswith('SWI') and not self.type.startswith('RELAY') and not self.type.startswith('HVAC')
 
 
 class Shade(Output):


### PR DESCRIPTION
The logic in the code seems to allocate everything not excluded to be dimmable, and thus later to be created in HA as light.
home-assistant provides an easy way to re-classify switches as lights if needed, so would be a better logic to only classify 'dimmable' the dimmers and hybrid keypads, everything else should a switch.  Lights cannot be reclassified easily as switches.
I believe this change captures all the possible devices types that should not be lights.