### PR TITLE
Identify SWITCHED_MOTOR outputs as non-dimmable

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -781,7 +781,7 @@ class Output(LutronEntity):
   @property
   def is_dimmable(self):
     """Returns a boolean of whether or not the output is dimmable."""
-    return self.type not in ('NON_DIM', 'NON_DIM_INC', 'NON_DIM_ELV', 'EXHAUST_FAN_TYPE', 'RELAY_LIGHTING') and not self.type.startswith('CCO_')
+    return self.type not in ('NON_DIM', 'NON_DIM_INC', 'NON_DIM_ELV', 'EXHAUST_FAN_TYPE', 'RELAY_LIGHTING', 'SWITCHED_MOTOR') and not self.type.startswith('CCO_')
 
 
 class Shade(Output):


### PR DESCRIPTION
This will address https://github.com/home-assistant/core/issues/127672

This properly identifies the output as non-dimmable which will properly label it as a switch in home assistant.