### PR TITLE
Fix unofficial support for Homeworks and improve unittests

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -65,8 +65,7 @@ class LutronConnection(threading.Thread):
   """Encapsulates the connection to the Lutron controller."""
   USER_PROMPT = b'login: '
   PW_PROMPT = b'password: '
-  PROMPT = b'GNET> '
-  ANY_PROMPT = re.compile(rb'[GQ]NET>')
+  PROMPT = re.compile(rb'[GQ]NET>')
 
   def __init__(self, host: str, user: str, password: str, recv_callback: Callable[[str], None], connection_factory: Any = telnetlib3.open_connection) -> None:
     """Initializes the lutron connection, doesn't actually connect."""
@@ -166,7 +165,7 @@ class LutronConnection(threading.Thread):
     
     # If we get USER_PROMPT again, it means login failed
     try:
-      await asyncio.wait_for(self._reader.readuntil_pattern(LutronConnection.ANY_PROMPT), timeout=10.0)
+      await asyncio.wait_for(self._reader.readuntil_pattern(LutronConnection.PROMPT), timeout=10.0)
     except asyncio.TimeoutError:
       _LOGGER.error("Timeout waiting for GNET or QNET prompt, checking if we are back at login")
       raise LutronLoginError("Timed out waiting for GNET/QNET prompt (check credentials)")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -50,7 +50,7 @@ class TestLutronConnection(AsyncTestBase):
         self.mock_reader.readuntil_pattern.return_value = b'QNET> '
         
         await self.conn._do_login()
-        self.mock_reader.readuntil_pattern.assert_called_with(LutronConnection.ANY_PROMPT)
+        self.mock_reader.readuntil_pattern.assert_called_with(LutronConnection.PROMPT)
 
     async def test_login_timeout_user_prompt(self) -> None:
         """Test timeout waiting for the initial login prompt."""


### PR DESCRIPTION
The old version of pylutron would silently ignore a failure to see the GNET> prompt but work fine on systems that properly implement the integration protocol like Homeworks.  This explicitly adds support for the QNET prompt and adds more robust unittests to verify propoer behavior with incorrect logins or timeouts.