### PR TITLE
Dispatch LEVEL_CHANGED event on set_level for QNET controllers

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -813,6 +813,9 @@ class Output(LutronEntity):
     self._lutron.send(Lutron.OP_EXECUTE, Output._CMD_TYPE, self._integration_id,
         Output._ACTION_ZONE_LEVEL, "%.2f" % new_level, self._fade_time(fade_time_seconds))
     self._level = new_level
+    # Dispatch event immediately for controllers (e.g. HomeWorks QS/QNET)
+    # that don't echo state changes back on the same connection.
+    self._dispatch_event(Output.Event.LEVEL_CHANGED, {'level': self._level})
 
   def flash(self, fade_time_seconds: Optional[float] = None) -> None:
     """Flashes the zone until a new level is set."""


### PR DESCRIPTION
## Problem

HomeWorks QS processors (QNET protocol) do not echo back `~OUTPUT` state changes on the same telnet connection that sent the `#OUTPUT` command. This means the `LEVEL_CHANGED` event was never dispatched after `set_level()`, causing Home Assistant to revert the UI toggle state.

**Observed behaviour:** Toggle a light on → light turns on → UI reverts to off. Toggle again → sends off command but light was already on, so nothing visible happens.

## Root Cause

GNET controllers (original HomeWorks) echo the state change as a monitoring event (`~OUTPUT,id,1,level`), which triggers `handle_update()` → `_dispatch_event()`. On QNET, `handle_update()` is never called for self-initiated changes because no echo is sent on the same connection.

## Fix

Dispatch `Output.Event.LEVEL_CHANGED` immediately after updating `self._level` in `set_level()`. This is safe for both GNET and QNET:

- **QNET:** This is the only notification that consumers receive — essential.
- **GNET:** The echo will also trigger `handle_update()`, dispatching a second event with the same level. This is harmless as consumers (like HA) are idempotent for same-value updates.

## Testing

Tested on Lutron HomeWorks QS Gulliver processors (firmware 15.10.0) — 558 entities (lights, switches, shades, occupancy sensors). Light toggles now correctly reflect state in Home Assistant.

Related: PR #122 added QNET prompt support. This PR completes QNET compatibility for state management.