### PR TITLE
Treat MOTOR outputs as binary motor loads

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -389,8 +389,10 @@ class LutronXmlDbParser(object):
     integration_id = int(output_xml.get('IntegrationID') or 0)
     uuid = output_xml.get('UUID') or ""
 
-    if output_type in ('SYSTEM_SHADE', 'MOTOR'):
+    if output_type == 'SYSTEM_SHADE':
       return Shade(self._lutron, name, watts, output_type, integration_id, uuid)
+    if output_type == 'MOTOR':
+      return MotorLoad(self._lutron, name, watts, output_type, integration_id, uuid)
     return Output(self._lutron, name, watts, output_type, integration_id, uuid)
 
   def _parse_keypad(self, keypad_xml: ET.Element, device_group: ET.Element) -> Keypad:
@@ -883,6 +885,32 @@ class Shade(Output):
     """Starts raising the shade."""
     self._lutron.send(Lutron.OP_EXECUTE, Output._CMD_TYPE, self._integration_id,
         Shade._ACTION_STOP)
+
+
+class MotorLoad(Output):
+  """This is the output entity for binary motor loads (e.g. LQSE-4M)."""
+  _ACTION_OPEN = 2
+  _ACTION_CLOSE = 3
+  _ACTION_STOP = 4
+
+  def open(self) -> None:
+    """Starts opening the motor load."""
+    self._lutron.send(Lutron.OP_EXECUTE, Output._CMD_TYPE, self._integration_id,
+        MotorLoad._ACTION_OPEN)
+
+  def close(self) -> None:
+    """Starts closing the motor load."""
+    self._lutron.send(Lutron.OP_EXECUTE, Output._CMD_TYPE, self._integration_id,
+        MotorLoad._ACTION_CLOSE)
+
+  def stop(self) -> None:
+    """Stops motor movement."""
+    self._lutron.send(Lutron.OP_EXECUTE, Output._CMD_TYPE, self._integration_id,
+        MotorLoad._ACTION_STOP)
+
+  def set_level(self, new_level: float, fade_time_seconds: Optional[float] = None) -> None:
+    """Motor loads are binary and should only be controlled with open/close/stop."""
+    raise ValueError("Motor loads are binary. Use open(), close(), or stop().")
 
 
 class KeypadComponent(LutronEntity):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,5 @@
 import unittest
-from pylutron import Lutron, LutronXmlDbParser
+from pylutron import Lutron, LutronXmlDbParser, MotorLoad
 
 # Minimal XML for testing
 MINIMAL_XML = """
@@ -28,6 +28,22 @@ MINIMAL_XML = """
                              </Devices>
                         </DeviceGroup>
                     </DeviceGroups>
+                </Area>
+            </Areas>
+        </Area>
+    </Areas>
+</Lutron>
+"""
+
+MOTOR_XML = """
+<Lutron>
+    <Areas>
+        <Area Name="Project">
+            <Areas>
+                <Area Name="Living Room" IntegrationID="1">
+                    <Outputs>
+                        <Output Name="Curtain Motor" IntegrationID="10" OutputType="MOTOR" Wattage="100" UUID="OUT-MOTOR-1" />
+                    </Outputs>
                 </Area>
             </Areas>
         </Area>
@@ -66,6 +82,15 @@ class TestLutronXmlDbParser(unittest.TestCase):
         self.assertEqual(output.watts, 100)
         self.assertEqual(output.type, 'NON_DIM')
         self.assertEqual(output.id, 2)
+
+    def test_parse_motor_output_as_motor_load(self) -> None:
+        parser = LutronXmlDbParser(self.lutron, MOTOR_XML)
+        parser.parse()
+        area = parser.areas[0]
+        self.assertEqual(len(area.outputs), 1)
+        output = area.outputs[0]
+        self.assertIsInstance(output, MotorLoad)
+        self.assertEqual(output.type, 'MOTOR')
 
     def test_parse_keypad(self) -> None:
         parser = LutronXmlDbParser(self.lutron, MINIMAL_XML)

--- a/tests/test_shade.py
+++ b/tests/test_shade.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import MagicMock
-from pylutron import Lutron, Shade, Output
+from pylutron import Lutron, Shade, MotorLoad
 
 from typing import Any, cast
 
@@ -12,7 +12,7 @@ class TestShade(unittest.TestCase):
         self.lutron.register_id = MagicMock() # type: ignore[method-assign]
 
     def test_shade_commands(self) -> None:
-        # Create a shade (Output with type SYSTEM_SHADE or MOTOR)
+        # Create a shade (Output with type SYSTEM_SHADE)
         shade = Shade(self.lutron, "Master Shade", 100, "SYSTEM_SHADE", 50, "uuid-shade")
         
         # Test start_raise
@@ -28,3 +28,24 @@ class TestShade(unittest.TestCase):
         # Test stop
         shade.stop()
         cast(MagicMock, self.lutron._conn.send).assert_called_with('#OUTPUT,50,4')
+
+    def test_motor_load_commands(self) -> None:
+        motor = MotorLoad(self.lutron, "Master Motor", 100, "MOTOR", 51, "uuid-motor")
+
+        motor.open()
+        cast(MagicMock, self.lutron._conn.send).assert_called_with('#OUTPUT,51,2')
+
+        motor.close()
+        cast(MagicMock, self.lutron._conn.send).assert_called_with('#OUTPUT,51,3')
+
+        motor.stop()
+        cast(MagicMock, self.lutron._conn.send).assert_called_with('#OUTPUT,51,4')
+
+    def test_motor_load_rejects_level_commands(self) -> None:
+        motor = MotorLoad(self.lutron, "Master Motor", 100, "MOTOR", 51, "uuid-motor")
+
+        with self.assertRaises(ValueError):
+            motor.set_level(100)
+
+        with self.assertRaises(ValueError):
+            motor.level = 0


### PR DESCRIPTION
## Summary
- Parse OutputType="MOTOR" as a dedicated MotorLoad entity
- Keep SYSTEM_SHADE mapped to Shade
- Implement binary motor actions only for MotorLoad: open(), close(), stop()
- Reject percentage control for motor loads by raising ValueError in set_level

## Why
LQSE-4M motor outputs should behave as binary motor loads (open/close/stop), not as percentage-position shades.

## Validation
- Added unit tests for MotorLoad commands and level rejection
- Added parser test to ensure MOTOR outputs become MotorLoad
- Ran full test suite: 61 passed

## Notes
- This preserves existing SYSTEM_SHADE behavior and only changes MOTOR handling.
