### PR TITLE
Add dual-connection support for HomeWorks QS status updates

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -72,7 +72,10 @@ class LutronConnection(threading.Thread):
   PW_PROMPT = b'password: '
   PROMPT = re.compile(rb'([GQ]NET>|login: )')
 
-  def __init__(self, host: str, user: str, password: str, recv_callback: Callable[[str], None], connection_factory: Any = telnetlib3.open_connection) -> None:
+  PROMPT_GNET = "GNET"
+  PROMPT_QNET = "QNET"
+
+  def __init__(self, host: str, user: str, password: str, recv_callback: Callable[[str], None], connection_factory: Any = telnetlib3.open_connection, enable_monitoring: bool = True) -> None:
     """Initializes the lutron connection, doesn't actually connect."""
     threading.Thread.__init__(self)
 
@@ -86,11 +89,22 @@ class LutronConnection(threading.Thread):
     self._connect_cond = threading.Condition(lock=self._lock)
     self._recv_cb = recv_callback
     self._connection_factory = connection_factory
+    self._enable_monitoring = enable_monitoring
+    self._prompt_type: Optional[str] = None
     self._done = False
     self._loop = asyncio.new_event_loop()
     self._exception: Optional[LutronException] = None
 
     self.daemon = True
+
+  @property
+  def prompt_type(self) -> Optional[str]:
+    """The prompt type returned by the controller after login.
+
+    Returns "GNET" for RadioRA 2 / QS Standalone, "QNET" for HomeWorks QS,
+    or None if login has not completed yet.
+    """
+    return self._prompt_type
 
   def connect(self) -> None:
     """Connects to the lutron controller."""
@@ -183,13 +197,20 @@ class LutronConnection(threading.Thread):
       _LOGGER.error("Timeout waiting for GNET or QNET prompt, checking if we are back at login")
       raise LutronLoginError("Timed out waiting for GNET/QNET prompt (check credentials)")
 
-    await self._send_coro("#MONITORING,12,2")
-    await self._send_coro("#MONITORING,255,2")
-    await self._send_coro("#MONITORING,3,1")
-    await self._send_coro("#MONITORING,4,1")
-    await self._send_coro("#MONITORING,5,1")
-    await self._send_coro("#MONITORING,6,1")
-    await self._send_coro("#MONITORING,8,1")
+    if b'QNET>' in res:
+      self._prompt_type = LutronConnection.PROMPT_QNET
+    else:
+      self._prompt_type = LutronConnection.PROMPT_GNET
+    _LOGGER.info("Detected prompt type: %s" % self._prompt_type)
+
+    if self._enable_monitoring:
+      await self._send_coro("#MONITORING,12,2")
+      await self._send_coro("#MONITORING,255,2")
+      await self._send_coro("#MONITORING,3,1")
+      await self._send_coro("#MONITORING,4,1")
+      await self._send_coro("#MONITORING,5,1")
+      await self._send_coro("#MONITORING,6,1")
+      await self._send_coro("#MONITORING,8,1")
 
   def _disconnect_locked(self) -> None:
     """Closes the current connection. Assume self._lock is held."""
@@ -496,6 +517,7 @@ class Lutron(object):
     self._password = password
     self._name = ""
     self._conn = LutronConnection(host, user, password, self._recv)
+    self._cmd_conn: Optional[LutronConnection] = None
     self._ids: Dict[str, Dict[int, LutronEntity]] = {}
     self._legacy_subscribers: Dict[LutronEntity, Callable[[LutronEntity], None]] = {}
     self._areas: List[Area] = []
@@ -572,15 +594,35 @@ class Lutron(object):
     obj = ids[integration_id]
     obj.handle_update(args)
 
+  @property
+  def is_homeworks(self) -> bool:
+    """True when connected to a HomeWorks QS processor (QNET prompt)."""
+    return self._conn.prompt_type == LutronConnection.PROMPT_QNET
+
   def connect(self) -> None:
-    """Connects to the Lutron controller to send and receive commands and status"""
+    """Connects to the Lutron controller to send and receive commands and status.
+
+    On HomeWorks QS systems (detected via the QNET> prompt), a second
+    connection is opened for sending commands. HomeWorks only delivers
+    status updates to sessions that did not originate the command, so the
+    primary connection is kept as a monitor-only session while commands
+    are routed through the dedicated send connection.
+    """
     self._conn.connect()
+
+    if self._conn.prompt_type == LutronConnection.PROMPT_QNET:
+      _LOGGER.info("HomeWorks QS detected, opening dedicated command connection")
+      self._cmd_conn = LutronConnection(
+          self._host, self._user, self._password,
+          self._recv, enable_monitoring=False)
+      self._cmd_conn.connect()
 
   def send(self, op: str, cmd: str, integration_id: int, *args: Any) -> None:
     """Formats and sends the requested command to the Lutron controller."""
     out_cmd = ",".join(
         (cmd, str(integration_id)) + tuple((str(x) for x in args if x is not None)))
-    self._conn.send(op + out_cmd)
+    conn = self._cmd_conn if self._cmd_conn is not None else self._conn
+    conn.send(op + out_cmd)
 
   def load_xml_db(self, cache_path: Optional[str] = None) -> bool:
     """Load the Lutron database from the server.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -48,9 +48,10 @@ class TestLutronConnection(AsyncTestBase):
             LutronConnection.PW_PROMPT
         ]
         self.mock_reader.readuntil_pattern.return_value = b'QNET> '
-        
+
         await self.conn._do_login()
         self.mock_reader.readuntil_pattern.assert_called_with(LutronConnection.PROMPT)
+        self.assertEqual(self.conn.prompt_type, LutronConnection.PROMPT_QNET)
 
     async def test_login_timeout_user_prompt(self) -> None:
         """Test timeout waiting for the initial login prompt."""

--- a/tests/test_homeworks.py
+++ b/tests/test_homeworks.py
@@ -1,0 +1,206 @@
+import unittest
+from unittest.mock import MagicMock, AsyncMock, patch, call
+import asyncio
+import time
+
+from pylutron import Lutron, LutronConnection, Output
+
+from typing import List, Optional, Tuple, cast
+
+
+class TestPromptTypeDetection(unittest.IsolatedAsyncioTestCase):
+    """Verifies LutronConnection correctly identifies GNET vs QNET prompts."""
+
+    def setUp(self) -> None:
+        self.mock_reader = AsyncMock()
+        self.mock_writer = MagicMock()
+        self.mock_writer.drain = AsyncMock()
+        self.mock_writer.get_extra_info.return_value = MagicMock()
+
+        async def factory(host: str, port: int, connect_timeout: Optional[float] = None, encoding: Optional[str] = None) -> Tuple[AsyncMock, MagicMock]:
+            return self.mock_reader, self.mock_writer
+
+        self.factory = factory
+        self.mock_reader.readuntil.side_effect = [
+            LutronConnection.USER_PROMPT,
+            LutronConnection.PW_PROMPT,
+        ]
+
+    async def test_gnet_prompt_sets_prompt_type(self) -> None:
+        conn = LutronConnection('1.1.1.1', 'u', 'p', lambda l: None,
+                                connection_factory=self.factory)
+        self.mock_reader.readuntil_pattern.return_value = b'GNET> '
+        await conn._do_login()
+        self.assertEqual(conn.prompt_type, LutronConnection.PROMPT_GNET)
+
+    async def test_qnet_prompt_sets_prompt_type(self) -> None:
+        conn = LutronConnection('1.1.1.1', 'u', 'p', lambda l: None,
+                                connection_factory=self.factory)
+        self.mock_reader.readuntil_pattern.return_value = b'QNET> '
+        await conn._do_login()
+        self.assertEqual(conn.prompt_type, LutronConnection.PROMPT_QNET)
+
+    async def test_prompt_type_none_before_login(self) -> None:
+        conn = LutronConnection('1.1.1.1', 'u', 'p', lambda l: None,
+                                connection_factory=self.factory)
+        self.assertIsNone(conn.prompt_type)
+
+
+class TestMonitoringControl(unittest.IsolatedAsyncioTestCase):
+    """Verifies that monitoring commands are sent or skipped based on
+    the enable_monitoring flag."""
+
+    def setUp(self) -> None:
+        self.mock_reader = AsyncMock()
+        self.mock_writer = MagicMock()
+        self.mock_writer.drain = AsyncMock()
+        self.mock_writer.get_extra_info.return_value = MagicMock()
+
+        async def factory(host: str, port: int, connect_timeout: Optional[float] = None, encoding: Optional[str] = None) -> Tuple[AsyncMock, MagicMock]:
+            return self.mock_reader, self.mock_writer
+
+        self.factory = factory
+        self.mock_reader.readuntil.side_effect = [
+            LutronConnection.USER_PROMPT,
+            LutronConnection.PW_PROMPT,
+        ]
+        self.mock_reader.readuntil_pattern.return_value = b'QNET> '
+
+    async def test_monitoring_enabled_sends_commands(self) -> None:
+        conn = LutronConnection('1.1.1.1', 'u', 'p', lambda l: None,
+                                connection_factory=self.factory,
+                                enable_monitoring=True)
+        await conn._do_login()
+        written = [c.args[0] for c in self.mock_writer.write.call_args_list]
+        monitoring_cmds = [w for w in written if b'#MONITORING' in w]
+        self.assertEqual(len(monitoring_cmds), 7)
+
+    async def test_monitoring_disabled_skips_commands(self) -> None:
+        conn = LutronConnection('1.1.1.1', 'u', 'p', lambda l: None,
+                                connection_factory=self.factory,
+                                enable_monitoring=False)
+        await conn._do_login()
+        written = [c.args[0] for c in self.mock_writer.write.call_args_list]
+        monitoring_cmds = [w for w in written if b'#MONITORING' in w]
+        self.assertEqual(len(monitoring_cmds), 0)
+
+
+class TestLutronDualConnection(unittest.TestCase):
+    """Tests the Lutron class dual-connection behavior for HomeWorks QS."""
+
+    def _make_mock_conn(self, prompt: str) -> MagicMock:
+        """Creates a mock LutronConnection with the given prompt type."""
+        conn = MagicMock(spec=LutronConnection)
+        conn.prompt_type = prompt
+        conn.connect.return_value = None
+        conn.send.return_value = None
+        return conn
+
+    def test_gnet_uses_single_connection(self) -> None:
+        """On RadioRA 2 (GNET), no command connection is created."""
+        lutron = Lutron('1.1.1.1', 'u', 'p')
+        mock_conn = self._make_mock_conn(LutronConnection.PROMPT_GNET)
+        lutron._conn = mock_conn
+
+        lutron.connect()
+
+        self.assertIsNone(lutron._cmd_conn)
+        self.assertFalse(lutron.is_homeworks)
+
+    def test_qnet_creates_command_connection(self) -> None:
+        """On HomeWorks QS (QNET), a second connection is opened for commands."""
+        lutron = Lutron('1.1.1.1', 'u', 'p')
+        mock_monitor = self._make_mock_conn(LutronConnection.PROMPT_QNET)
+        lutron._conn = mock_monitor
+
+        cmd_conn = self._make_mock_conn(LutronConnection.PROMPT_QNET)
+        created_conns: list[object] = []
+        original_init = LutronConnection.__init__
+
+        def capture_init(self_inner: LutronConnection, *args: object, **kwargs: object) -> None:
+            created_conns.append(self_inner)
+
+        with patch.object(LutronConnection, '__init__', capture_init):
+            with patch.object(LutronConnection, 'connect'):
+                lutron.connect()
+
+        self.assertIsNotNone(lutron._cmd_conn)
+        self.assertTrue(lutron.is_homeworks)
+
+    def test_send_routes_to_cmd_conn_on_homeworks(self) -> None:
+        """Commands are sent via the command connection on HomeWorks."""
+        lutron = Lutron('1.1.1.1', 'u', 'p')
+        mock_monitor = self._make_mock_conn(LutronConnection.PROMPT_QNET)
+        mock_cmd = self._make_mock_conn(LutronConnection.PROMPT_QNET)
+        lutron._conn = mock_monitor
+        lutron._cmd_conn = mock_cmd
+
+        lutron.send(Lutron.OP_EXECUTE, 'OUTPUT', 5, 1, '100.00')
+
+        mock_cmd.send.assert_called_once_with('#OUTPUT,5,1,100.00')
+        mock_monitor.send.assert_not_called()
+
+    def test_send_routes_to_conn_on_radiora(self) -> None:
+        """Commands are sent via the single connection on RadioRA 2."""
+        lutron = Lutron('1.1.1.1', 'u', 'p')
+        mock_conn = self._make_mock_conn(LutronConnection.PROMPT_GNET)
+        lutron._conn = mock_conn
+
+        lutron.send(Lutron.OP_EXECUTE, 'OUTPUT', 5, 1, '100.00')
+
+        mock_conn.send.assert_called_once_with('#OUTPUT,5,1,100.00')
+
+    def test_monitor_receives_status_updates(self) -> None:
+        """Status updates on the monitor connection dispatch to handle_update."""
+        lutron = Lutron('1.1.1.1', 'u', 'p')
+        lutron._conn = MagicMock()
+        output = Output(lutron, 'Light', 40, 'INC', 10, '714')
+        handler = MagicMock()
+        output.subscribe(handler, None)
+
+        lutron._recv('~OUTPUT,10,1,75.00')
+
+        self.assertEqual(output.last_level(), 75.0)
+        handler.assert_called_once()
+
+
+class TestLutronDualConnectionIntegration(unittest.TestCase):
+    """End-to-end test using mock telnet sessions simulating HomeWorks QS."""
+
+    def test_command_on_cmd_conn_generates_update_on_monitor(self) -> None:
+        """Simulates: command sent on cmd_conn, status update arrives on
+        monitor, handle_update fires."""
+        received: List[str] = []
+
+        def recv_cb(line: str) -> None:
+            received.append(line)
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.get_extra_info.return_value = MagicMock()
+
+        async def factory(host: str, port: int, connect_timeout: Optional[float] = None, encoding: Optional[str] = None) -> Tuple[AsyncMock, MagicMock]:
+            return mock_reader, mock_writer
+
+        mock_reader.readuntil.side_effect = lambda p: p
+        mock_reader.readuntil_pattern.return_value = b'QNET> '
+        mock_reader.readline.side_effect = [
+            b'~OUTPUT,10,1,75.00\r\n',
+            b'',
+        ]
+
+        conn = LutronConnection('1.1.1.1', 'u', 'p', recv_cb,
+                                connection_factory=factory)
+        conn.connect()
+        time.sleep(0.2)
+
+        self.assertEqual(conn.prompt_type, LutronConnection.PROMPT_QNET)
+        self.assertIn('~OUTPUT,10,1,75.00', received)
+
+        conn._done = True
+        conn.join(timeout=1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

HomeWorks QS (QNET) only delivers status updates to telnet sessions that did **not** originate the command. With a single connection, commands sent by pylutron never generate inbound `handle_update` callbacks for the caller's own actions -- lights/shades/motors appear to not respond even though the hardware moves.

This PR implements the standard industry workaround: when the `QNET>` prompt is detected after login, a second `LutronConnection` is opened for sending commands while the original connection is kept as a monitor-only session. On RadioRA 2 / QS Standalone (`GNET>`), behavior is unchanged -- single connection as before.

## Changes

**`LutronConnection`:**
- Detects the prompt type (`GNET` vs `QNET`) from the login response and exposes it via a `prompt_type` property and class constants `PROMPT_GNET` / `PROMPT_QNET`.
- New `enable_monitoring` constructor parameter (default `True`). When `False`, the `#MONITORING` subscription commands are skipped during login. The command connection doesn't need monitoring -- the monitor connection handles all inbound status updates.

**`Lutron`:**
- `connect()` checks `prompt_type` after the initial connection. If `QNET`, it creates a second `LutronConnection` with `enable_monitoring=False` and stores it as `_cmd_conn`.
- `send()` routes commands through `_cmd_conn` when present, falling back to `_conn` on RadioRA 2.
- New `is_homeworks` property for downstream consumers (e.g. Home Assistant) to detect the connection mode.
- The command connection uses `self._recv` as its callback so that query responses (`?OUTPUT,...`) are still processed -- query responses return to the requesting session even on HWQS, unlike unsolicited status updates.

**Wire diagram:**
```
RadioRA 2 (GNET>):
  self._conn  ──── send + monitor + recv_cb ────  Controller

HomeWorks QS (QNET>):
  self._conn      ──── monitor + recv_cb ────┐
                                              ├──  Controller
  self._cmd_conn  ──── send + recv_cb ───────┘
```

**Reconnection:** Both connections use `LutronConnection._main_loop` independently, each handling their own reconnect-on-drop cycle. Since both connect to the same host, transient network issues will typically affect both simultaneously.

## Test plan

- [x] New `tests/test_homeworks.py` with 11 tests:
  - Prompt type detection: GNET sets `PROMPT_GNET`, QNET sets `PROMPT_QNET`, `None` before login
  - Monitoring control: 7 `#MONITORING` commands sent when enabled, 0 when disabled
  - `Lutron.connect()` on GNET: no `_cmd_conn` created, `is_homeworks` is `False`
  - `Lutron.connect()` on QNET: `_cmd_conn` created, `is_homeworks` is `True`
  - Command routing: `send()` goes to `_cmd_conn` on HWQS, `_conn` on RadioRA 2
  - Status update dispatch: `_recv` on monitor connection fires `handle_update`
  - Integration test: mock QNET session receives status update lines through the full pipeline
- [x] Updated `tests/test_connection.py`: existing QNET login test now also asserts `prompt_type`
- [x] Full test suite passes (69 tests)
- [x] `mypy --strict` clean on all 16 source files
- [ ] Manual verification on real HomeWorks QS hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)
