### PR TITLE
Fix intermittent truncated DbXmlInfo.xml download

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -602,7 +602,14 @@ class Lutron(object):
     if not loaded_from:
       import urllib.request
       url = 'http://' + self._host + '/DbXmlInfo.xml'
-      with urllib.request.urlopen(url) as xmlfile:
+      # Some repeaters (e.g. HomeWorks QS) serve DbXmlInfo.xml over HTTP/1.1 with
+      # no Content-Length and keep the connection open. With no length delimiter,
+      # read() relies on the server closing the connection to signal end-of-body,
+      # and under load a short read can return a truncated document that fails to
+      # parse ("not well-formed (invalid token)"). Ask the server to close the
+      # connection so the body is delimited by EOF, and set an explicit timeout.
+      req = urllib.request.Request(url, headers={'Connection': 'close'})
+      with urllib.request.urlopen(req, timeout=60) as xmlfile:
         xml_db = xmlfile.read()
         loaded_from = 'repeater'
 


### PR DESCRIPTION
### Problem

On a Lutron HomeWorks QS system, `load_xml_db()` intermittently fails while downloading the integration database:

```
xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 18, column 424267
```

The failure is not deterministic. It reproduces reliably when the host process is busy (for example during Home Assistant startup, where the fetch runs in an executor thread while many other integrations initialize); the same call from an idle interpreter usually succeeds. When it fails, the `lutron` integration setup aborts and no devices load.

### Root cause

The HomeWorks QS repeater serves `http://<host>/DbXmlInfo.xml` over HTTP/1.1 **without a `Content-Length` header** and keeps the connection open. With no length delimiter, `urllib`'s `read()` relies on the server closing the connection to signal end-of-body; under load a short read can return early, yielding a truncated (and therefore not-well-formed) XML document. The full document on this system is ~960 KB; truncated reads have been observed around 420 KB.

### Fix

Ask the server to close the connection after the response (so the body is delimited by EOF) and set an explicit read timeout:

```python
req = urllib.request.Request(url, headers={'Connection': 'close'})
with urllib.request.urlopen(req, timeout=60) as xmlfile:
    xml_db = xmlfile.read()
    loaded_from = 'repeater'
```

### Testing

- Reproduced the truncation during Home Assistant startup on a HomeWorks QS system (115 dimmers / 25 shades / ~960 KB DB).
- With the change, repeated fetches return the complete document (verified the body ends with `</Project>`), and the `lutron` integration sets up reliably across restarts.
- A stronger variant (raw `GET ... HTTP/1.0` + `Connection: close`, read to EOF) was also verified and is equivalent; the header change above is the minimal fix.

No API change; `cache_path` behavior is unchanged.
