### PR TITLE
Always send a level command, even when the cache agrees

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -838,8 +838,6 @@ class Output(LutronEntity):
 
   def set_level(self, new_level: float, fade_time_seconds: Optional[float] = None) -> None:
     """Sets the new output level."""
-    if self._level == new_level:
-      return
     self._lutron.send(Lutron.OP_EXECUTE, Output._CMD_TYPE, self._integration_id,
         Output._ACTION_ZONE_LEVEL, "%.2f" % new_level, self._fade_time(fade_time_seconds))
     self._level = new_level

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -37,5 +37,28 @@ class TestOutput(unittest.TestCase):
         self.assertTrue(handled)
         self.assertEqual(self.output.last_level(), 75.0)
 
+    def test_set_level_is_not_suppressed_by_a_stale_cache(self) -> None:
+        """Setting the level must always send, even if the cache agrees.
+
+        The cached level is only as good as the last report from the
+        controller. It goes stale whenever a report is lost, and on systems
+        that do not send unsolicited reports for a given change it is stale by
+        construction. Suppressing the command then leaves the caller with no
+        way to reassert a level: the first request appears to work, every
+        identical one after it is silently dropped.
+        """
+        send = cast(MagicMock, self.lutron._conn.send)
+        self.output.set_level(50.0)
+        self.output.set_level(50.0)
+        self.assertEqual(send.call_count, 2)
+
+    def test_set_level_honours_a_new_fade_time(self) -> None:
+        """Same level, different fade, is a different command."""
+        send = cast(MagicMock, self.lutron._conn.send)
+        self.output.set_level(50.0)
+        self.output.set_level(50.0, fade_time_seconds=4)
+        send.assert_called_with('#OUTPUT,1,1,50.00,0:00:04')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### The problem

`Output.set_level()` returns early when the cached level already equals the
requested one:

```python
def set_level(self, new_level, fade_time_seconds=None):
    if self._level == new_level:
        return
```

That cached value is only as good as the last report from the controller. It
goes stale whenever a report is lost, and on a system that does not send
unsolicited reports for a particular kind of change it is stale by
construction.

When it is stale the caller has no way to reassert a level. The first request
appears to work and every identical one after it is silently dropped — no
command on the wire, no error, nothing observable from the outside. From a
Home Assistant user's point of view the light control simply stops working
after one use, and pressing the same value again does nothing.

The guard also swallows a command that differs only in fade time, which is a
different command with a different effect:

```python
out.set_level(50.0)
out.set_level(50.0, fade_time_seconds=4)   # never sent
```

Suppressing a *state write* on an unchanged value is reasonable. Suppressing
the *command* is not, because the cache is not authoritative — it is a copy of
what the controller last told us, not of what the controller currently is.

### Tests

Two tests added in `tests/test_output.py`. Both fail on `master`:

```
FAIL: test_set_level_is_not_suppressed_by_a_stale_cache  ->  AssertionError: 1 != 2
FAIL: test_set_level_honours_a_new_fade_time             ->  expected call not found
```

Full suite: 71 tests pass, `mypy` clean.

### Related

Same underlying theme as #133: state that is assumed fresh but can silently go
stale. They are independent changes and can be taken in either order.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
