### PR TITLE
Run CI on pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -6,7 +6,7 @@ name: Python application
 on:
   push:
     branches: [ "master", "main", "unittests" ]
-  pull_request_target:
+  pull_request:
     branches: [ "master", "main" ]
   workflow_dispatch:
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/type_checking.yml
+++ b/.github/workflows/type_checking.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/type_checking.yml
+++ b/.github/workflows/type_checking.yml
@@ -3,7 +3,7 @@ name: Type Checking
 on:
   push:
     branches: [ master, type-checking ]
-  pull_request_target:
+  pull_request:
     branches: [ master ]
   workflow_dispatch:
 


### PR DESCRIPTION
actions/checkout now refuses to fetch fork pull-request code inside a pull_request_target workflow (it runs with the base repository's token and secrets), so every fork PR since July fails all checks before a single test runs. These workflows only install the package and run pytest/mypy; they need no secrets, so the plain pull_request event is the right trigger.

I have reviewed PR #127 and its intent, but two things happened since then that have made the April approach stop working:

- https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/
It announces actions/checkout v7, which refuses to fetch fork pull-request code in pull_request_target workflows when ref: is the PR head or merge commit, names ref: ${{ github.event.pull_request.head.sha }} explicitly as one of the now-refused inputs, and states that the pull_request event is unchanged. An editor's note on the post moved the backport enforcement date from July 16 to July 20.

- https://github.com/actions/checkout/releases/tag/v4.4.0
Release v4.4.0, published 2026-07-20, whose notes read "[BREAKING] backport allow-unsafe-pr-checkout to v4" and link to the changelog above. The same day shipped the parallel backports v5.1.0, v6.1.0, v3.7.0 and v2.8.0. The floating v4 tag now resolves to the v4.4.0 commit, so any workflow pinned to actions/checkout@v4 picked up the refusal without any change in the repository. The `allow-unsafe-pr-checkout` input introduced there is the opt-in is one way around this problem. The other way is the change proposed in this PR.