### PR TITLE
Keep reconnecting after a failed retry once connected

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -82,6 +82,7 @@ class LutronConnection(threading.Thread):
     self._reader: Optional[telnetlib3.TelnetReader] = None
     self._writer: Optional[telnetlib3.TelnetWriter] = None
     self._connected = False
+    self._ever_connected = False
     self._lock = threading.Lock()
     self._connect_cond = threading.Condition(lock=self._lock)
     self._recv_cb = recv_callback
@@ -213,6 +214,7 @@ class LutronConnection(threading.Thread):
         await self._do_login()
         with self._lock:
           self._connected = True
+          self._ever_connected = True
           self._connect_cond.notify_all()
         _LOGGER.info("Connected")
 
@@ -231,13 +233,13 @@ class LutronConnection(threading.Thread):
         self._done = True
       except _EXPECTED_NETWORK_EXCEPTIONS as e:
         _LOGGER.exception("Network exception in main loop")
-        # If we have not yet connected, don't try to reconnect
-        if not self._connected:
+        # If we have never connected, don't try to reconnect
+        if not self._ever_connected:
           self._exception = LutronConnectionError(str(e))
           self._done = True
       except Exception as e:
         _LOGGER.exception("Uncaught exception in main loop")
-        if not self._connected:
+        if not self._ever_connected:
           self._exception = LutronException(str(e))
           self._done = True
       

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -197,7 +197,7 @@ class LutronConnection(threading.Thread):
         raise LutronAuthenticationError("Incorrect username or password")
     except asyncio.TimeoutError:
       _LOGGER.error("Timeout waiting for GNET or QNET prompt, checking if we are back at login")
-      raise LutronLoginError("Timed out waiting for GNET/QNET prompt (check credentials)")
+      raise LutronLoginError("Timed out waiting for GNET/QNET prompt")
 
     await self._send_coro("#MONITORING,12,2")
     await self._send_coro("#MONITORING,255,2")

--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -41,7 +41,22 @@ class LutronException(Exception):
 
 
 class LutronLoginError(LutronException):
-  """Raised when login fails."""
+  """Raised when login fails.
+
+  Covers both genuine credential rejection (see LutronAuthenticationError) and
+  transient login-time timeouts. The reconnect loop treats a bare
+  LutronLoginError (a timeout) as retryable once we've connected before.
+  """
+  pass
+
+
+class LutronAuthenticationError(LutronLoginError):
+  """Raised when the controller rejects the username/password.
+
+  Distinct from a login timeout (also a LutronLoginError): bad credentials
+  never become valid by retrying, so the reconnect loop treats this as fatal
+  even after an earlier successful connection.
+  """
   pass
 
 
@@ -179,7 +194,7 @@ class LutronConnection(threading.Thread):
       # Wait for either the GNET/QNET prompt or the login prompt again
       res = await asyncio.wait_for(self._reader.readuntil_pattern(LutronConnection.PROMPT), timeout=10.0)
       if LutronConnection.USER_PROMPT in res:
-        raise LutronLoginError("Incorrect username or password")
+        raise LutronAuthenticationError("Incorrect username or password")
     except asyncio.TimeoutError:
       _LOGGER.error("Timeout waiting for GNET or QNET prompt, checking if we are back at login")
       raise LutronLoginError("Timed out waiting for GNET/QNET prompt (check credentials)")
@@ -225,12 +240,22 @@ class LutronConnection(threading.Thread):
             _LOGGER.warning("Connection closed by remote")
             break
           self._recv_cb(line.decode('ascii').rstrip())
-      except LutronException as e:
-        _LOGGER.exception("Fatal error during login")
-        # For fatal errors like auth failure, we might want to stop or notify
-        # For now, let's stop the loop to avoid infinite spamming
+      except LutronAuthenticationError as e:
+        # Bad credentials never become valid by retrying, so give up whether or
+        # not we've connected before.
+        _LOGGER.exception("Authentication failed")
         self._exception = e
         self._done = True
+      except LutronException as e:
+        # Login timeouts (LutronLoginError) and other Lutron errors are
+        # transient once we've connected at least once -- e.g. the controller
+        # is slow to answer the login prompt right after a network blip. Only
+        # give up if we have never successfully connected, matching the network
+        # branch below; otherwise fall through to the reconnect sleep.
+        _LOGGER.exception("Error during login")
+        if not self._ever_connected:
+          self._exception = e
+          self._done = True
       except _EXPECTED_NETWORK_EXCEPTIONS as e:
         _LOGGER.exception("Network exception in main loop")
         # If we have never connected, don't try to reconnect

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -234,6 +234,41 @@ class TestLutronConnection(AsyncTestBase):
         self.assertTrue(self.conn._done)
         self.assertIsInstance(self.conn._exception, LutronAuthenticationError)
 
+    async def test_main_loop_retries_network_failure_after_connect(self) -> None:
+        """A network failure on a reconnect (after a successful connect) must retry.
+
+        This is the 0.4.2 regression itself. _disconnect_locked() runs at the end of
+        every iteration and clears _connected, so guarding the network branch on
+        _connected misreads the retry as a never-connected failure: the loop sets
+        _done after exactly one reconnect attempt and the reader thread ends for
+        good. Guarding on _ever_connected keeps it retrying.
+
+        First _do_login() succeeds (the inner read loop breaks on an empty line,
+        simulating the drop); every later call raises OSError, which is in
+        _EXPECTED_NETWORK_EXCEPTIONS and is what a refused reconnect actually
+        raises. Reverting the guard to `if not self._connected` makes _do_login run
+        exactly twice, which this test catches.
+        """
+        calls = {'n': 0}
+
+        async def do_login() -> None:
+            calls['n'] += 1
+            if calls['n'] == 1:
+                self.conn._reader = self.mock_reader
+                self.mock_reader.readline.return_value = b""
+                return
+            if calls['n'] >= 3:
+                self.conn._done = True  # stop the loop once we've proven it retried
+            raise OSError(113, "Connect call failed ('192.168.1.50', 23)")
+
+        with patch.object(LutronConnection, '_do_login', side_effect=do_login), \
+             patch('pylutron.asyncio.sleep', new=AsyncMock()):
+            await self.conn._main_loop()
+
+        self.assertGreaterEqual(calls['n'], 3,
+                                "network failure after a successful connect must retry, not give up")
+        self.assertIsNone(self.conn._exception)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -80,18 +80,25 @@ class TestLutronConnection(AsyncTestBase):
         with self.assertRaisesRegex(LutronLoginError, "Timed out waiting for GNET/QNET prompt"):
             await self.conn._do_login()
 
-    async def test_incorrect_credentials_retry_login(self) -> None:
-        """Test behavior when credentials are incorrect."""
+    async def test_login_timeout_is_not_an_authentication_error(self) -> None:
+        """A GNET/QNET timeout must stay transient, not become a fatal auth error.
+
+        The other half of the policy pinned by test_incorrect_credentials_assertive:
+        a timeout raises the base LutronLoginError, so _main_loop retries it once
+        connected. Raising LutronAuthenticationError here instead would make a slow
+        repeater permanently fatal.
+        """
         self.mock_reader.readuntil.side_effect = [
             LutronConnection.USER_PROMPT,
             LutronConnection.PW_PROMPT
         ]
         self.mock_reader.readuntil_pattern.side_effect = asyncio.TimeoutError
-        
+
         with self.assertRaises(LutronLoginError) as cm:
             await self.conn._do_login()
-        
-        self.assertIn("check credentials", str(cm.exception).lower())
+
+        self.assertNotIsInstance(cm.exception, LutronAuthenticationError)
+        self.assertIn("gnet/qnet prompt", str(cm.exception).lower())
 
     async def test_incorrect_credentials_assertive(self) -> None:
         """Test assertive reporting of incorrect credentials."""
@@ -102,7 +109,7 @@ class TestLutronConnection(AsyncTestBase):
         # Simulate repeater sending back the login prompt on failure
         self.mock_reader.readuntil_pattern.return_value = LutronConnection.USER_PROMPT
         
-        with self.assertRaisesRegex(LutronLoginError, "Incorrect username or password"):
+        with self.assertRaisesRegex(LutronAuthenticationError, "Incorrect username or password"):
             await self.conn._do_login()
 
     def test_thread_start_and_connect(self) -> None:
@@ -198,7 +205,7 @@ class TestLutronConnection(AsyncTestBase):
                 return
             if calls['n'] >= 3:
                 self.conn._done = True  # stop the loop after we've proven it retried
-            raise LutronLoginError("Timed out waiting for GNET/QNET prompt (check credentials)")
+            raise LutronLoginError("Timed out waiting for GNET/QNET prompt")
 
         with patch.object(LutronConnection, '_do_login', side_effect=do_login), \
              patch('pylutron.asyncio.sleep', new=AsyncMock()):
@@ -267,6 +274,38 @@ class TestLutronConnection(AsyncTestBase):
 
         self.assertGreaterEqual(calls['n'], 3,
                                 "network failure after a successful connect must retry, not give up")
+        self.assertIsNone(self.conn._exception)
+
+    async def test_main_loop_retries_unexpected_exception_after_connect(self) -> None:
+        """An unexpected exception on a reconnect must retry too, once connected.
+
+        The generic `except Exception` branch carries the same one-line guard as the
+        other two and had no coverage. Same bug class as the 0.4.2 network regression,
+        lower stakes: reverting this guard to `if not self._connected:` makes the loop
+        give up after a single reconnect attempt, because _disconnect_locked() has
+        already cleared _connected by then.
+
+        ValueError stands in for anything not caught by the two branches above -- it
+        is neither a LutronException nor in _EXPECTED_NETWORK_EXCEPTIONS.
+        """
+        calls = {'n': 0}
+
+        async def do_login() -> None:
+            calls['n'] += 1
+            if calls['n'] == 1:
+                self.conn._reader = self.mock_reader
+                self.mock_reader.readline.return_value = b""
+                return
+            if calls['n'] >= 3:
+                self.conn._done = True  # stop the loop once we've proven it retried
+            raise ValueError("unexpected failure during reconnect")
+
+        with patch.object(LutronConnection, '_do_login', side_effect=do_login), \
+             patch('pylutron.asyncio.sleep', new=AsyncMock()):
+            await self.conn._main_loop()
+
+        self.assertGreaterEqual(calls['n'], 3,
+                                "unexpected exception after a successful connect must retry, not give up")
         self.assertIsNone(self.conn._exception)
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, AsyncMock, patch
 import asyncio
 import threading
 import time
-from pylutron import LutronConnection, LutronLoginError, LutronConnectionError
+from pylutron import LutronConnection, LutronLoginError, LutronConnectionError, LutronAuthenticationError
 from typing import List, Optional, Tuple, Any
 
 class AsyncTestBase(unittest.IsolatedAsyncioTestCase):
@@ -157,13 +157,11 @@ class TestLutronConnection(AsyncTestBase):
             self.conn._done = True
             self.conn.join(timeout=1)
 
-    def test_disconnect_preserves_ever_connected(self) -> None:
-        """A disconnect must not erase the fact that we once connected.
+    def test_disconnect_does_not_clear_ever_connected(self) -> None:
+        """_disconnect_locked() clears _connected but must leave _ever_connected set.
 
-        Regression: the reconnect guard in _main_loop tested self._connected, but
-        _disconnect_locked() clears that flag before the retry runs. The first failed
-        reconnect therefore looked like a never-connected failure, set _done = True,
-        and the reader thread exited permanently after a single retry.
+        Narrow unit check on the flag only. It does NOT exercise the reconnect
+        guard in _main_loop -- see test_main_loop_* below for that.
         """
         async def mock_do_login_success() -> None:
             self.mock_reader.readline.return_value = b""
@@ -178,6 +176,63 @@ class TestLutronConnection(AsyncTestBase):
             self.assertTrue(self.conn._ever_connected)
             self.conn._done = True
             self.conn.join(timeout=1)
+
+    async def test_main_loop_retries_login_timeout_after_connect(self) -> None:
+        """A login timeout on a reconnect (after a successful connect) must retry.
+
+        Drives _main_loop directly: first _do_login() succeeds (so _ever_connected
+        becomes True and the inner read loop breaks on an empty line), every later
+        call raises a login timeout -- a LutronLoginError, the same type raised by
+        _do_login()'s three asyncio.TimeoutError paths. With the reconnect guard in
+        place the loop keeps retrying; reverting it (the except LutronException
+        branch setting _done unconditionally) makes _do_login run exactly twice and
+        _exception get set, which this test would catch.
+        """
+        calls = {'n': 0}
+
+        async def do_login() -> None:
+            calls['n'] += 1
+            if calls['n'] == 1:
+                self.conn._reader = self.mock_reader
+                self.mock_reader.readline.return_value = b""
+                return
+            if calls['n'] >= 3:
+                self.conn._done = True  # stop the loop after we've proven it retried
+            raise LutronLoginError("Timed out waiting for GNET/QNET prompt (check credentials)")
+
+        with patch.object(LutronConnection, '_do_login', side_effect=do_login), \
+             patch('pylutron.asyncio.sleep', new=AsyncMock()):
+            await self.conn._main_loop()
+
+        self.assertGreaterEqual(calls['n'], 3,
+                                "login timeout after a successful connect must retry, not give up")
+        self.assertIsNone(self.conn._exception)
+
+    async def test_main_loop_stops_on_authentication_error(self) -> None:
+        """Bad credentials must stay fatal, even after a successful connect.
+
+        Same harness as the retry test, but the reconnect raises
+        LutronAuthenticationError ("Incorrect username or password"). The loop must
+        set _done and stop rather than retry a credential that will never work.
+        """
+        calls = {'n': 0}
+
+        async def do_login() -> None:
+            calls['n'] += 1
+            if calls['n'] == 1:
+                self.conn._reader = self.mock_reader
+                self.mock_reader.readline.return_value = b""
+                return
+            raise LutronAuthenticationError("Incorrect username or password")
+
+        with patch.object(LutronConnection, '_do_login', side_effect=do_login), \
+             patch('pylutron.asyncio.sleep', new=AsyncMock()):
+            await self.conn._main_loop()
+
+        self.assertEqual(calls['n'], 2,
+                         "bad credentials must be fatal even after a successful connect")
+        self.assertTrue(self.conn._done)
+        self.assertIsInstance(self.conn._exception, LutronAuthenticationError)
 
 
 if __name__ == '__main__':

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -157,5 +157,28 @@ class TestLutronConnection(AsyncTestBase):
             self.conn._done = True
             self.conn.join(timeout=1)
 
+    def test_disconnect_preserves_ever_connected(self) -> None:
+        """A disconnect must not erase the fact that we once connected.
+
+        Regression: the reconnect guard in _main_loop tested self._connected, but
+        _disconnect_locked() clears that flag before the retry runs. The first failed
+        reconnect therefore looked like a never-connected failure, set _done = True,
+        and the reader thread exited permanently after a single retry.
+        """
+        async def mock_do_login_success() -> None:
+            self.mock_reader.readline.return_value = b""
+            await asyncio.sleep(0.1)
+
+        with patch.object(LutronConnection, '_do_login', side_effect=mock_do_login_success):
+            self.conn.connect()
+            self.assertTrue(self.conn._ever_connected)
+            with self.conn._lock:
+                self.conn._disconnect_locked()
+            self.assertFalse(self.conn._connected)
+            self.assertTrue(self.conn._ever_connected)
+            self.conn._done = True
+            self.conn.join(timeout=1)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The reconnect guard in `_main_loop` tests `self._connected`, but `_disconnect_locked()` clears that flag before the retry runs:

```python
except _EXPECTED_NETWORK_EXCEPTIONS as e:
  # If we have not yet connected, dont try to reconnect
  if not self._connected:        # already cleared by the disconnect above
    self._done = True
...
self._disconnect_locked()        # sets self._connected = False
if not self._done:
  await asyncio.sleep(5)
```

So the first exception (dropped while connected) correctly does not give up, but the retry 5s later is misread as a never-connected failure and sets `_done = True`, ending the reader thread for good.

Net effect: **exactly one reconnect attempt, 5 seconds after a drop** — the moment a controller that just dropped the session is least likely to accept a login. Miss it and the connection is gone until the process restarts.

It is also silent: `send()` returns early when disconnected and logs only at debug, so commands are dropped with no exception. In Home Assistant the entities stay available and update optimistically, so the UI looks healthy while nothing reaches the controller. I hit this on a HomeWorks system — a brief network blip left every light, cover and keypad LED unresponsive for 12 hours with nothing in the log after:

```
12:07:42 ERROR [pylutron] Network exception in main loop   (_main_loop 221)
12:07:42 WARNING [pylutron] Disconnected
12:07:47 ERROR [pylutron] Network exception in main loop   (_main_loop 213 -> _do_login 139)
```

**Fix:** track "have we ever connected" separately from "are we connected right now", which is what the guard's own comment describes. Initial-connection failures still fail fast so `connect()` raises; a live connection now retries indefinitely on the existing 5s backoff.

Adds a regression test; it fails without the change. Full suite passes (75 tests).

