### PR TITLE
Fix checkout for fork pull requests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/type_checking.yml
+++ b/.github/workflows/type_checking.yml
@@ -7,12 +7,16 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
+        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
     - name: Set up Python


### PR DESCRIPTION
PRs #133, #134, and #135 currently fail in actions/checkout before Python setup, tests, or mypy run because pull_request_target tries to fetch fork-owned head SHAs from the base repository. This explicitly checks out the pull request head repository at its immutable SHA, falls back to the current repository for push/manual runs, and gives the type-checking workflow read-only contents permission. This PR may initially show the same checkout failure because pull_request_target loads the workflow from master; after merge, rerun the checks on #133, #134, and #135. Verified locally: workflow regression checks, YAML parsing, 69 unit tests, mypy, and git diff --check all pass.