### PR TITLE
Dispatch events over a snapshot of the subscriber list

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -747,8 +747,14 @@ class LutronEntity(object):
     raise NotImplementedError
 
   def _dispatch_event(self, event: LutronEvent, params: Dict[str, Any]) -> None:
-    """Dispatches the specified event to all the subscribers."""
-    for handler, context in self._subscribers:
+    """Dispatches the specified event to all the subscribers.
+
+    Iterates a snapshot: a handler may unsubscribe itself, and consumers may
+    unsubscribe from another thread while the reader thread is dispatching.
+    Mutating the list under a live iterator silently skips the element after
+    the removed one, so some subscribers would miss the event entirely.
+    """
+    for handler, context in list(self._subscribers):
       handler(self, context, event, params)
 
   def subscribe(self, handler: LutronEventHandler, context: Any) -> Callable[[], None]:

--- a/tests/test_extended.py
+++ b/tests/test_extended.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import MagicMock
-from pylutron import Lutron, LutronXmlDbParser, Button, Keypad, LutronEntity, LutronEvent
+from pylutron import Lutron, LutronXmlDbParser, Button, Keypad, LutronEntity, LutronEvent, Output
 
 # Anonymized XML based on the real DbXmlInfo.xml structure
 LEGACY_AND_COMPLEX_XML = """<?xml version="1.0" encoding="UTF-8" ?>
@@ -157,6 +157,50 @@ class TestExtendedCoverage(unittest.TestCase):
         # Registering the same ID again should raise
         with self.assertRaises(IntegrationIdExistsError):
             self.lutron.register_id(Output._CMD_TYPE, output)
+
+
+class TestDispatchDuringUnsubscribe(unittest.TestCase):
+    """Unsubscribing while an event is being dispatched must not skip anyone."""
+
+    def test_unsubscribing_handler_does_not_skip_the_next_subscriber(self) -> None:
+        """_dispatch_event iterated the live list, so a removal skipped an element.
+
+        Reproduced deterministically here by having the first handler unsubscribe
+        itself, which is the same list mutation Home Assistant performs from its
+        own thread when an entity is removed (async_on_remove fires pylutron's
+        unsubscribe callable while the reader thread may be dispatching).
+
+        Without the snapshot, removing index 0 mid-iteration shifts the list and
+        the loop jumps straight to 'third' -- 'second' silently never fires.
+        """
+        lutron = Lutron('127.0.0.1', 'user', 'pass')
+        entity = LutronEntity(lutron, 'Test Entity', 'uuid-1')
+        called = []
+        unsub = {}
+
+        def first(obj, context, event, params):
+            called.append('first')
+            unsub['first']()
+
+        def second(obj, context, event, params):
+            called.append('second')
+
+        def third(obj, context, event, params):
+            called.append('third')
+
+        unsub['first'] = entity.subscribe(first, None)
+        entity.subscribe(second, None)
+        entity.subscribe(third, None)
+
+        entity._dispatch_event(Output.Event.LEVEL_CHANGED, {'level': 50.0})
+
+        self.assertEqual(called, ['first', 'second', 'third'],
+                         "a subscriber was skipped when another unsubscribed mid-dispatch")
+        # The removal still took effect for subsequent events.
+        called.clear()
+        entity._dispatch_event(Output.Event.LEVEL_CHANGED, {'level': 60.0})
+        self.assertEqual(called, ['second', 'third'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`LutronEntity._dispatch_event` iterated the subscriber list live:

```python
    for handler, context in self._subscribers:
      handler(self, context, event, params)
```

Any removal during a dispatch shifts the list under the iterator, so the element *after* the removed one is skipped — that subscriber never sees the event, and nothing is logged.

## Why it has not bitten anyone yet

`subscribe()` returns an unsubscribe callable, but consumers have generally subscribed and never detached, so removals never happened and the list was only ever appended to.

That is about to change. Home Assistant currently drops the returned callable, which leaks callbacks into removed entities (home-assistant/core#181995). The fix there is to wire it into `async_on_remove` — and that fires the removal from HA's event loop thread while this library's reader thread may be mid-dispatch. Entities that are *staying* would then start intermittently missing updates whenever some other entity is removed, which is a worse failure than the leak being fixed: silent, and it looks like the repeater dropped an event.

So this wants to land before, or with, that HA change.

## The fix

Iterate a snapshot. `list()` of a list is atomic under the GIL, so the copy itself needs no lock, and a removal concurrent with a dispatch now simply takes effect from the next event onward.

## Test

A handler that unsubscribes itself is the deterministic version of the cross-thread race — same list mutation, same iterator, no timing involved. Three subscribers, the first removes itself; the test asserts all three fire and that the removal still takes effect on the following event.

Verified by reverting the one-line change: `test_unsubscribing_handler_does_not_skip_the_next_subscriber` fails, with `second` missing from the call list.

76 tests pass, `mypy` clean.

## Note

This is independent of #142 (`disconnect()`) and branches off `master`, so the two can land in either order. Both came out of the same review pass over the Home Assistant integration's teardown path.
