### PR TITLE
Wait on _ever_connected in connect(), not _connected

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -110,7 +110,14 @@ class LutronConnection(threading.Thread):
     self.daemon = True
 
   def connect(self) -> None:
-    """Connects to the lutron controller."""
+    """Connects to the lutron controller.
+
+    Returns once the initial connection has succeeded, or raises if it could
+    not be established. Returning means we got connected at least once, not
+    that the connection is up right now -- the session may already have dropped
+    and be in the reconnect loop. That is the only guarantee available here,
+    since the controller can close the session at any moment.
+    """
     if self._connected or self.is_alive():
       raise ConnectionExistsError("Already connected")
     # After starting the thread we wait for it to post us
@@ -118,8 +125,11 @@ class LutronConnection(threading.Thread):
     # ensures that the caller only resumes when we are fully connected.
     self.start()
     with self._lock:
-      self._connect_cond.wait_for(lambda: self._connected or self._done)
-      if not self._connected and self._done:
+      # _ever_connected, not _connected: a session that comes up and drops
+      # before we reacquire the lock would otherwise leave the predicate false
+      # in both terms, and we would wait forever. _ever_connected latches.
+      self._connect_cond.wait_for(lambda: self._ever_connected or self._done)
+      if not self._ever_connected and self._done:
         if self._exception:
           raise self._exception
         raise LutronConnectionError("Failed to connect to Lutron controller")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -163,7 +163,10 @@ class TestLutronConnection(AsyncTestBase):
             
         with patch.object(LutronConnection, '_do_login', side_effect=mock_do_login_success):
             self.conn.connect()
-            self.assertTrue(self.conn._connected)
+            # As in test_thread_start_and_connect: this fixture's readline drops
+            # the session immediately, so _connected may already be False by the
+            # time connect() returns. _ever_connected is what connect() promises.
+            self.assertTrue(self.conn._ever_connected)
             self.conn._done = True
             self.conn.join(timeout=1)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -122,7 +122,10 @@ class TestLutronConnection(AsyncTestBase):
         self.mock_reader.readline.side_effect = [b"~OUTPUT,1,1,100.0\r\n", b""]
 
         self.conn.connect()
-        self.assertTrue(self.conn._connected)
+        # connect() guarantees we got connected at least once, not that we are
+        # connected right now: this fixture's readline drops the session after
+        # one line, so _connected may already be back to False.
+        self.assertTrue(self.conn._ever_connected)
         time.sleep(0.1)
         self.assertIn('~OUTPUT,1,1,100.0', self.received_lines)
         
@@ -307,6 +310,63 @@ class TestLutronConnection(AsyncTestBase):
         self.assertGreaterEqual(calls['n'], 3,
                                 "unexpected exception after a successful connect must retry, not give up")
         self.assertIsNone(self.conn._exception)
+
+
+
+class TestLutronConnectionConnect(unittest.TestCase):
+    """connect() must not wait on a flag the reader may already have cleared."""
+
+    def setUp(self) -> None:
+        self.mock_reader = AsyncMock()
+        self.mock_writer = MagicMock()
+        self.mock_writer.drain = AsyncMock()
+
+        async def factory(host: str, port: int, connect_timeout: Optional[float] = None,
+                          encoding: Optional[str] = None) -> Tuple[AsyncMock, MagicMock]:
+            return self.mock_reader, self.mock_writer
+
+        self.conn = LutronConnection('127.0.0.1', 'user', 'pass', lambda line: None,
+                                     connection_factory=factory)
+
+    def tearDown(self) -> None:
+        self.conn.disconnect(timeout=2.0)
+
+    def test_connect_returns_when_the_session_drops_immediately(self) -> None:
+        """A session accepted and closed at once must not hang connect().
+
+        _main_loop sets _connected then notifies, but if the first read returns
+        nothing the loop falls straight through to _disconnect_locked() and
+        clears the flag again -- possibly before this thread reacquires the lock
+        and re-checks. Waiting on _connected then leaves the predicate false in
+        both terms (_done is False, the loop is retrying) and connect() never
+        returns. Waiting on _ever_connected, which latches, cannot do that.
+
+        connect() runs on a helper thread so a regression fails the test instead
+        of hanging the whole suite.
+        """
+        async def do_login() -> None:
+            self.conn._reader = self.mock_reader
+            self.conn._writer = self.mock_writer
+            self.mock_reader.readline = AsyncMock(return_value=b"")
+
+        returned = threading.Event()
+        errors: List[BaseException] = []
+
+        def call_connect() -> None:
+            try:
+                self.conn.connect()
+            except BaseException as exc:   # noqa: BLE001 - re-checked below
+                errors.append(exc)
+            finally:
+                returned.set()
+
+        with patch.object(LutronConnection, '_do_login', side_effect=do_login):
+            threading.Thread(target=call_connect, daemon=True).start()
+            self.assertTrue(returned.wait(10.0),
+                            "connect() hung after the session dropped immediately")
+
+        self.assertEqual(errors, [], f"connect() raised: {errors}")
+        self.assertTrue(self.conn._ever_connected)
 
 
 


### PR DESCRIPTION
Closes #141.

`connect()` waited on the wrong flag and could block forever:

```python
      self._connect_cond.wait_for(lambda: self._connected or self._done)
```

`_main_loop` sets `_connected`, notifies, then reads. If that read returns nothing the loop falls straight through to `_disconnect_locked()` and clears the flag again — possibly before the waiting thread reacquires the lock and re-evaluates the predicate. `_done` is `False` because the loop is retrying, so both terms are false and `wait_for` goes back to sleep. Nothing sets `_connected` again unless a later reconnect happens to be observed by the waiter, so in practice `connect()` never returns.

A controller that accepts a session and immediately drops it is not exotic — the connection limit, a reboot, or another integration's session being torn down all produce it.

The fix is the flag added in #138: `_ever_connected` latches and is never cleared, which is exactly the property the predicate needs.

## Why it matters beyond one blocked thread

Home Assistant calls `connect()` from `async_setup_entry` without wrapping it in an executor, so this does not hang a worker — it hangs HA's event loop, with no timeout and no error. See home-assistant/core#181995.

## Behaviour change

A successful `connect()` now means **"the initial connection succeeded"**, not "the connection is up right now".

That is the only guarantee this function can honestly make. The controller may close the session at any moment, including between the connect and the return, so no predicate here can promise the caller a live connection — the old one did not either, it just blocked instead of admitting it. Consumers that need current state should check it rather than infer it from `connect()` returning.

The docstring now says this explicitly, and `test_thread_start_and_connect` asserts `_ever_connected` instead of `_connected`: its own fixture drops the session after a single line, so it was quietly depending on winning that race.

## Test

`test_connect_returns_when_the_session_drops_immediately` reproduces it with no hardware — `_do_login` succeeds and the first `readline()` returns `b""`. `connect()` runs on a helper thread so a reappearance fails the test in 10s rather than hanging the suite.

Verified by reverting the one-line predicate change: the new test fails on the `returned.wait(10.0)` assertion. 83 tests pass, `mypy` clean.
